### PR TITLE
Now we can pass additional containers to worker pod

### DIFF
--- a/spark/README.md
+++ b/spark/README.md
@@ -79,22 +79,26 @@ $ kubectl proxy --api-prefix=/spark-ui-proxy
 
 ### Spark Worker
 
-| Parameter                    | Description                        | Default                                                    |
-| -----------------------      | ---------------------------------- | ---------------------------------------------------------- |
-| `Worker.Name`                | Spark worker name                  | `spark-worker`                                             |
-| `Worker.Image`               | Container image name               | `gcr.io/google_containers/spark`                           |
-| `Worker.ImageTag`            | Container image tag                | `1.5.1_v3`                                                 |
-| `Worker.Replicas`            | k8s hpa and deployment replicas    | `3`                                                        |
-| `Worker.ReplicasMax`         | k8s hpa max replicas               | `10`                                                       |
-| `Worker.Component`           | k8s selector key                   | `spark-worker`                                             |
-| `Worker.Cpu`                 | container requested cpu            | `100m`                                                     |
-| `Worker.Memory`              | container requested memory         | `512Mi`                                                    |
-| `Worker.ContainerPort`       | Container listening port           | `7077`                                                     |
-| `Worker.CpuTargetPercentage` | k8s hpa cpu targetPercentage       | `50`                                                       |
-| `Worker.DaemonMemory`        | Worker JVM Xms and Xmx setting     | `1g`                                                       |
-| `Worker.ExecutorMemory`      | Worker memory available for executor | `1g`                                                       |
-| `Worker.NodeSelector`        | Worker k8s node selector           | `{}`
+| Parameter                        | Description                          | Default                                                    |
+| -------------------------------- | ------------------------------------ | ---------------------------------------------------------- |
+| `Worker.Name`                    | Spark worker name                    | `spark-worker`                                             |
+| `Worker.Image`                   | Container image name                 | `gcr.io/google_containers/spark`                           |
+| `Worker.ImageTag`                | Container image tag                  | `1.5.1_v3`                                                 |
+| `Worker.Replicas`                | k8s hpa and deployment replicas      | `3`                                                        |
+| `Worker.ReplicasMax`             | k8s hpa max replicas                 | `10`                                                       |
+| `Worker.Component`               | k8s selector key                     | `spark-worker`                                             |
+| `Worker.Cpu`                     | container requested cpu              | `100m`                                                     |
+| `Worker.Memory`                  | container requested memory           | `512Mi`                                                    |
+| `Worker.ContainerPort`           | Container listening port             | `7077`                                                     |
+| `Worker.CpuTargetPercentage`     | k8s hpa cpu targetPercentage         | `50`                                                       |
+| `Worker.DaemonMemory`            | Worker JVM Xms and Xmx setting       | `1g`                                                       |
+| `Worker.ExecutorMemory`          | Worker memory available for executor | `1g`                                                       |
+| `Worker.NodeSelector`            | Worker k8s node selector             | `{}`                                                       |
+| `Worker.AdditionalPodContainers` | Container config to spawn            | `{}`                                                       |
 
+See [values.yaml](values.yaml) file to get an example of how to pass the `AdditionalPodContainers` configuration
+
+### Loading the chart
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/spark/templates/spark-worker-daemonset.yaml
+++ b/spark/templates/spark-worker-daemonset.yaml
@@ -33,6 +33,12 @@ spec:
             value: {{ default "1g" .Values.Worker.ExecutorMemory | quote }}
           - name: SPARK_NO_DAEMONIZE
             value: "yes"
+      {{- range $key, $value := .Values.Worker.AdditionalPodContainers }}
+      {{- if $value }}
+        - name: {{ $key }}
+{{ toYaml $value | indent 10 }}
+      {{- end }}
+      {{- end }}
     {{- if .Values.Worker.NodeSelector }}
       nodeSelector:
 {{ toYaml .Values.Worker.NodeSelector | indent 8 }}

--- a/spark/values.yaml
+++ b/spark/values.yaml
@@ -53,4 +53,9 @@ Worker:
   # Set how much total memory workers have to give executors
   #ExecutorMemory: 1g
   #NodeSelector:
-    #srcd.host/type: worker
+  #  srcd.host/type: worker
+  #AdditionalPodContainers:
+  #  bblfsh-server:
+  #    image: bblfsh/server:latest
+  #    securityContext:
+  #      privileged: true


### PR DESCRIPTION
This will enable the possibility to colocate bblfsh containers in the same pod as we have spark workers so that we access them locally

Config hasn't been set as an array of hashes as it is not possible to pass that kind of structure with `--set` option