### PR TITLE
add tiller helm chart

### DIFF
--- a/tiller/.helmignore
+++ b/tiller/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/tiller/Chart.yaml
+++ b/tiller/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: tiller
+version: 0.1.0

--- a/tiller/README.md
+++ b/tiller/README.md
@@ -1,0 +1,12 @@
+# Tiller Helm Chart
+
+YAML template from
+
+```
+helm init --dry-run --debug
+```
+
+from a v2.5.0 helm installation
+
+This is meant to be used by Terraform Helm provisioner that currently does not support installing the tiller
+

--- a/tiller/templates/tiller-svc-deployment.yaml
+++ b/tiller/templates/tiller-svc-deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: helm
+    name: tiller
+  name: tiller-deploy
+  namespace: kube-system
+spec:
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: helm
+        name: tiller
+    spec:
+      containers:
+      - env:
+        - name: TILLER_NAMESPACE
+          value: kube-system
+        image: gcr.io/kubernetes-helm/tiller:v2.5.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /liveness
+            port: 44135
+          initialDelaySeconds: 1
+          timeoutSeconds: 1
+        name: tiller
+        ports:
+        - containerPort: 44134
+          name: tiller
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 44135
+          initialDelaySeconds: 1
+          timeoutSeconds: 1
+        resources: {}
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: helm
+    name: tiller
+  name: tiller-deploy
+  namespace: kube-system
+spec:
+  ports:
+  - name: tiller
+    port: 44134
+    targetPort: tiller
+  selector:
+    app: helm
+    name: tiller
+  type: ClusterIP
+status:
+  loadBalancer: {}
+...


### PR DESCRIPTION
This is meant to be used by terraform helm provider that currently does
not support tiller installation