### PR TITLE
drone: remove chart version from deployment's labels

### DIFF
--- a/drone/Chart.yaml
+++ b/drone/Chart.yaml
@@ -5,7 +5,7 @@
 # kubernetes/charts is licensed under the Apache License 2.0
 
 name: drone
-version: 0.1.1
+version: 0.1.2
 description: Drone CI
 keywords:
 - continuous-deployment

--- a/drone/templates/deployment-agent.yaml
+++ b/drone/templates/deployment-agent.yaml
@@ -13,7 +13,6 @@ spec:
     metadata:
       labels:
         app: {{ template "fullname" . }}-agent
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:

--- a/drone/templates/deployment-server.yaml
+++ b/drone/templates/deployment-server.yaml
@@ -13,7 +13,6 @@ spec:
     metadata:
       labels:
         app: {{ template "fullname" . }}-server
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:


### PR DESCRIPTION
If present, upgrades won't work when changing the chart version.

Kubernetes discourages making label selector updates because the new selector does not select ReplicaSets or Pods created with the old selector, resulting in orphaning all old ReplicaSets and Pods and creating new ones (see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#label-selector-updates)