### PR TITLE
Kube certs manager chart

### DIFF
--- a/kube-cert-manager/.helmignore
+++ b/kube-cert-manager/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/kube-cert-manager/Chart.yaml
+++ b/kube-cert-manager/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: Manages Let's Encrypt TLS certificates for Kubernetes
+name: kube-cert-manager
+version: 0.1.0

--- a/kube-cert-manager/README.md
+++ b/kube-cert-manager/README.md
@@ -1,0 +1,26 @@
+# Kube cert manager
+
+This chart deploys [kube-cert-manager](https://github.com/PalmStoneGames/kube-cert-manager)
+
+## Pre-requisites
+
+- Kubernetes 1.7+
+- kube-cert-manager 0.5.0+
+
+## Scope
+
+This is intended to use Google DNS for Let's Encrypt challenges. `kube-cert-manager` supports more challenges, but we're currently only interested in those.
+
+## Installing the Chart
+
+To install the chart with the release name `kcm` using the key from a Google Service Account with `DNSAdmin` role in the file `google-key.json`:
+
+```bash
+helm install -n kcm . --set \
+google.base64JsonKey="$(cat google-key.json | base64)",\
+google.project=srcd-production
+```
+
+## Configuration
+
+See `values.yaml` for the available configuration parameters.

--- a/kube-cert-manager/templates/_helpers.tpl
+++ b/kube-cert-manager/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/kube-cert-manager/templates/certificate-type.yaml
+++ b/kube-cert-manager/templates/certificate-type.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.installCertificateType }}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.stable.k8s.psg.io
+spec:
+  scope: Namespaced
+  group: stable.k8s.psg.io
+  version: v1
+  names:
+    kind: Certificate
+    plural: certificates
+    singular: certificate
+{{ end }}

--- a/kube-cert-manager/templates/deployment.yaml
+++ b/kube-cert-manager/templates/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "-data-dir=/var/lib/cert-manager"
+            # We only support googlecloud for the moment in this chart
+            - "-default-provider=googlecloud"
+            {{ if .Values.args.staging }}
+            - "-acme-url=https://acme-staging.api.letsencrypt.org/directory"
+            {{ else }}
+            - "-acme-url=https://acme-v01.api.letsencrypt.org/directory"
+            {{ end }}
+            {{ if .Values.args.class }}
+            # You can run multiple instances of kube-cert-manager for the same namespace(s),
+            # each watching for a different value for the 'class' label
+            - "-class={{ .Values.args.class }}"
+            {{ end }}
+            {{ if .Values.args.namespaces }}
+            # You can choose to monitor only some namespaces, otherwise all namespaces will be monitored
+            "-namespaces={{ .Values.args.namespaces }}"
+            {{ end }}
+            # If you set a default email, you can omit the field/annotation from Certificates/Ingresses
+            {{ if .Values.args.defaultEmail }}
+            - "-default-email={{ .Values.args.defaultEmail }}"
+            {{ end }}
+            {{ if .Values.args.renewBeforeDays }}
+            - "-renew-before-days={{ .Values.args.renewBeforeDays }}"
+            {{ end }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/cert-manager
+            - name: google-application-credentials
+              mountPath: /var/secrets/google
+          env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /var/secrets/google/key.json
+            - name: GCE_PROJECT
+              value: {{ required "Missing google project" .Values.google.project }}
+      volumes:
+        - name: "data"
+          persistentVolumeClaim:
+            claimName: {{ template "fullname" . }}
+        - name: google-application-credentials
+          secret:
+            secretName: {{ template "fullname" . }}-google-key
+

--- a/kube-cert-manager/templates/google-key-secret.yaml
+++ b/kube-cert-manager/templates/google-key-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fullname" . }}-google-key
+type: Opaque
+data:
+  key.json: {{ required "Missing google key" .Values.google.base64JsonKey }}

--- a/kube-cert-manager/templates/persistent-volume-claim.yaml
+++ b/kube-cert-manager/templates/persistent-volume-claim.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: {{ template "fullname" . }}
+  name: {{ template "fullname" . }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/kube-cert-manager/values.yaml
+++ b/kube-cert-manager/values.yaml
@@ -1,0 +1,11 @@
+# Default values for kube-cert-manager.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+installCertificateType: true
+image:
+  repository: quay.io/srcd/kube-cert-manager
+  tag: latest
+  pullPolicy: IfNotPresent
+args:
+  staging: true


### PR DESCRIPTION
Running in development cluster with image `quay.io/srcd/kube-cert-manager:v0.5.0-srcd-1` built from our [kube-cert-manager fork](https://github.com/src-d/kube-cert-manager) running