### PR TITLE
Make image.tag required in borges chart

### DIFF
--- a/borges/Chart.yaml
+++ b/borges/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: borges
-version: 0.1.2
+version: 0.1.3

--- a/borges/templates/consumer-deployment.yaml
+++ b/borges/templates/consumer-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ required "Missing borges image tag" .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - borges

--- a/borges/templates/producer-deployment.yaml
+++ b/borges/templates/producer-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ required "Missing borges image tag" .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - borges

--- a/borges/values.yaml
+++ b/borges/values.yaml
@@ -3,7 +3,8 @@
 # Declare variables to be passed into your templates.
 image:
   repository: quay.io/srcd/borges
-  tag: v0.9.0
+  # This value should be provided when releasing this chart
+  # tag: v0.9.1
   pullPolicy: IfNotPresent
 consumer:
   workers: 12


### PR DESCRIPTION
This parameter must be provided when deploying the chart.