### PR TITLE
Moved to bblfshd from bblfsh-server

### DIFF
--- a/bblfsh-dashboard/Chart.yaml
+++ b/bblfsh-dashboard/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: bblfsh-dashboard
-version: 0.1.1
+version: 0.1.2
 description: |
     A web interface for Babelfish (https://doc.bblf.sh/).

--- a/bblfsh-dashboard/templates/deployment-using-external-bblfshd-server.yaml
+++ b/bblfsh-dashboard/templates/deployment-using-external-bblfshd-server.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.settings.serverAddr }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -16,19 +17,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
-{{- if .Values.settings.serverAddr }}
-        - -bblfsh-addr={{ .Values.serverAddr }}
-{{- else }}
-        - -bblfsh-addr=localhost:9432
-{{- end }}
+        - -bblfsh-addr={{ .Values.settings.serverAddr }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
-{{- if not .Values.settings.serverAddr }}
-      - name: bblfsh-server
-        image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
-        imagePullPolicy: {{ .Values.server.image.pullPolicy }}
-        securityContext:
-          privileged: true
-        resources:
-{{ toYaml .Values.server.resources | indent 10 }}
 {{- end }}

--- a/bblfsh-dashboard/templates/deployment-with-sidecar-bblfshd-container.yaml
+++ b/bblfsh-dashboard/templates/deployment-with-sidecar-bblfshd-container.yaml
@@ -1,0 +1,52 @@
+{{- if not .Values.settings.serverAddr }}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      # This is to upgrade the deployment if configmap changes
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/install-bblfshd-drivers-configmap.yaml") . | sha256sum }}
+      labels:
+        app: {{ template "fullname" . }}
+    spec:
+      {{- if .Values.server.drivers.install }}
+      volumes:
+        - configMap:
+            name: install-bblfshd-drivers
+            items:
+            - key: install-bblfshd-drivers.sh
+              path: install-bblfshd-drivers.sh
+          name: install-bblfshd-drivers-volume
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+        - -bblfsh-addr=localhost:9432
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+      - name: bblfshd
+        image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
+        imagePullPolicy: {{ .Values.server.image.pullPolicy }}
+        {{- if .Values.server.drivers.install }}
+        volumeMounts:
+          - name: install-bblfshd-drivers-volume
+            mountPath: /opt/install-bblfshd-drivers.sh
+            subPath: install-bblfshd-drivers.sh
+        lifecycle:
+          postStart:
+            exec:
+              command: [ "sh", "/opt/install-bblfshd-drivers.sh" ]
+        {{- end }}
+        securityContext:
+          privileged: true
+        resources:
+{{ toYaml .Values.server.resources | indent 10 }}
+{{- end }}

--- a/bblfsh-dashboard/templates/install-bblfshd-drivers-configmap.yaml
+++ b/bblfsh-dashboard/templates/install-bblfshd-drivers-configmap.yaml
@@ -1,0 +1,13 @@
+{{- if not .Values.settings.serverAddr }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: install-bblfshd-drivers
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+data:
+  install-bblfshd-drivers.sh: |
+    {{- range $language, $driver := .Values.server.drivers.languages }}
+    bblfshctl driver install {{ $language }} {{ $driver.repository }}:{{ $driver.tag }}
+    {{- end }}
+{{- end }}

--- a/bblfsh-dashboard/templates/service.yaml
+++ b/bblfsh-dashboard/templates/service.yaml
@@ -5,8 +5,8 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
-  type: LoadBalancer
-  {{- if .Values.service.loadBalancerIP }}
+  type: {{ .Values.service.type }}
+  {{- if and ( eq .Values.service.type "LoadBalancer" ) .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ default "" .Values.service.loadBalancerIP }}
   {{- end }}
   ports:

--- a/bblfsh-dashboard/values.yaml
+++ b/bblfsh-dashboard/values.yaml
@@ -4,13 +4,15 @@
 replicaCount: 1
 image:
   repository: bblfsh/dashboard
-  tag: v0.3.0
+  tag: v0.4.0
   pullPolicy: IfNotPresent
 service:
+  type: LoadBalancer
   name: bblfsh-dashboard
   ## port where the dashboard will be listen at the LoadBalancer.
   port: 80
   ## loadBalancerIP if not set an ephermeral IP will be used.
+  # This setting will only be used for LoadBalancer type
   loadBalancerIP:
 settings:
   ## serverAddr is the address to a bblfsh server, if empty a bblfsh server
@@ -23,7 +25,16 @@ resources: {}
 # configuration for build-in server if, settings.serverAddr is empty.
 server:
   image:
-    repository: bblfsh/server
-    tag: v1.2.0
+    repository: bblfsh/bblfshd
+    tag: v2.2.2
     pullPolicy: IfNotPresent
+  drivers:
+    install: true
+    languages:
+      python:
+        repository: bblfsh/python-driver
+        tag: v1.2.6
+      java:
+        repository: bblfsh/java-driver
+        tag: v1.2.2
   resources: {}


### PR DESCRIPTION
Separated the deployments with/without server in two files to make it clearer.

Drivers are installed from a list rather than using --all or --recommended as that would open the possibility of having different version of the drivers in the different pods of the deployment