### PR TITLE
Spark Workers fixes

### DIFF
--- a/spark/templates/spark-worker-daemonset.yaml
+++ b/spark/templates/spark-worker-daemonset.yaml
@@ -16,6 +16,10 @@ spec:
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         component: "{{ .Release.Name }}-{{ .Values.Worker.Component }}"
     spec:
+      volumes:
+        - name: spark-tmp
+          hostPath:
+            path: /data-a/spark-temp-data
       containers:
         - name: {{ template "worker-fullname" . }}
           image: "{{ .Values.Worker.Image }}:{{ .Values.Worker.ImageTag }}"
@@ -26,6 +30,9 @@ spec:
             requests:
               cpu: "{{ .Values.Worker.Cpu }}"
               memory: "{{ .Values.Worker.Memory }}"
+          volumeMounts:
+            - mountPath: /spark-temp-data
+              name: spark-tmp
           env:
           - name: SPARK_DAEMON_MEMORY
             value: {{ default "1g" .Values.Worker.DaemonMemory | quote }}
@@ -33,6 +40,8 @@ spec:
             value: {{ default "1g" .Values.Worker.ExecutorMemory | quote }}
           - name: SPARK_NO_DAEMONIZE
             value: "yes"
+          - name: SPARK_LOCAL_DIRS
+            value: "/spark-temp-data"
       {{- range $key, $value := .Values.Worker.AdditionalPodContainers }}
       {{- if $value }}
         - name: {{ $key }}

--- a/spark/templates/spark-worker-deployment.yaml
+++ b/spark/templates/spark-worker-deployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: extensions/v1beta1
-kind: DaemonSet
+kind: Deployment
 metadata:
   name: {{ template "worker-fullname" . }}
   labels:
@@ -8,6 +8,12 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: "{{ .Release.Name }}-{{ .Values.Worker.Component }}"
 spec:
+  replicas: {{ default 1 .Values.Worker.Replicas }}
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      component: "{{ .Release.Name }}-{{ .Values.Worker.Component }}"
   template:
     metadata:
       labels:


### PR DESCRIPTION
This PR takes on two different tasks:
- Changes spark's temporary folder to a path that resides on disk (https://github.com/src-d/issues-infrastructure/issues/100)
- Makes workers to be run via a deployment and not a daemonset (https://github.com/src-d/issues-infrastructure/issues/78)

This PR goes in hand with https://github.com/src-d/infrastructure/pull/45