### PR TITLE
Spark: remove chart version from pod's metadata

### DIFF
--- a/spark/Chart.yaml
+++ b/spark/Chart.yaml
@@ -16,7 +16,7 @@
 # https://github.com/kubernetes/charts/tree/master/stable/spark
 
 name: spark
-version: 0.0.1
+version: 0.0.2
 description: Fast and general-purpose cluster computing system.
 home: http://spark.apache.org
 icon: http://spark.apache.org/images/spark-logo-trademark.png

--- a/spark/templates/spark-master-deployment.yaml
+++ b/spark/templates/spark-master-deployment.yaml
@@ -52,7 +52,6 @@ spec:
       labels:
         heritage: {{ .Release.Service | quote }}
         release: {{ .Release.Name | quote }}
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         component: "{{ .Release.Name }}-{{ .Values.Master.Component }}"
     spec:
       containers:

--- a/spark/templates/spark-webui-proxy-deployment.yaml
+++ b/spark/templates/spark-webui-proxy-deployment.yaml
@@ -31,7 +31,6 @@ spec:
       labels:
         heritage: {{ .Release.Service | quote }}
         release: {{ .Release.Name | quote }}
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         component: "{{ .Release.Name }}-{{ .Values.WebUiProxy.Component }}"
     spec:
       containers:

--- a/spark/templates/spark-worker-daemonset.yaml
+++ b/spark/templates/spark-worker-daemonset.yaml
@@ -13,7 +13,6 @@ spec:
       labels:
         heritage: {{ .Release.Service | quote }}
         release: {{ .Release.Name | quote }}
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         component: "{{ .Release.Name }}-{{ .Values.Worker.Component }}"
     spec:
       volumes:


### PR DESCRIPTION
If not, it prevents helm from upgrading pods when chart's version is bumped.