### PR TITLE
moved to standard helm naming convention

### DIFF
--- a/spark/Chart.yaml
+++ b/spark/Chart.yaml
@@ -16,7 +16,7 @@
 # https://github.com/kubernetes/charts/tree/master/stable/spark
 
 name: spark
-version: 0.1.0
+version: 0.1.1
 description: Fast and general-purpose cluster computing system.
 home: http://spark.apache.org
 icon: http://spark.apache.org/images/spark-logo-trademark.png

--- a/spark/templates/_helpers.tpl
+++ b/spark/templates/_helpers.tpl
@@ -3,26 +3,26 @@
 Expand the name of the chart.
 */}}
 {{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create fully qualified names.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "master-fullname" -}}
-{{- $name := default .Chart.Name .Values.Master.Name -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.Master.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "webui-fullname" -}}
-{{- $name := default .Chart.Name .Values.WebUi.Name -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.WebUi.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "worker-fullname" -}}
-{{- $name := default .Chart.Name .Values.Worker.Name -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.Worker.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "worker-temporary-dir" -}}
@@ -31,6 +31,6 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "webui-proxy-fullname" -}}
-{{- $name := default .Chart.Name .Values.WebUiProxy.Name -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.WebUiProxy.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}


### PR DESCRIPTION
This also fixes a bug where we could not use "spark" as release name as it was setting the `SPARK_MASTER_PORT` variable (which is used internally by spark init scripts)

```
$ helm install spark --name=spark
NAME:   spark
LAST DEPLOYED: Mon Mar 12 14:12:47 2018
NAMESPACE: default
STATUS: DEPLOYED

RESOURCES:
==> v1/Service
NAME                     CLUSTER-IP      EXTERNAL-IP  PORT(S)   AGE
spark-spark-webui        10.99.103.187   <none>       8080/TCP  0s
spark-spark-master       10.107.183.164  <none>       7077/TCP  0s
spark-spark-webui-proxy  10.106.201.248  <none>       80/TCP    0s

==> v1beta1/Deployment
NAME                     DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
spark-spark-master       1        1        1           0          0s
spark-spark-worker       1        1        1           0          0s
spark-spark-webui-proxy  1        1        1           0          0s


NOTES:
1. Get the Spark URL to visit by running these commands in the same shell:

  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
  You can watch its status by running 'kubectl get svc --namespace default -w spark-spark-webui'

  export SPARK_SERVICE_IP=$(kubectl get svc --namespace default spark-spark-webui -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
  echo http://$SPARK_SERVICE_IP:8080

charts rporres(k8s: minikube) $ kubectl get pods -o wide
NAME                                       READY     STATUS    RESTARTS   AGE       IP           NODE
spark-spark-master-5b799fd6b6-gzngh        1/1       Running   0          8s        172.17.0.5   minikube
spark-spark-webui-proxy-54bcd6d779-tp4xd   1/1       Running   0          8s        172.17.0.7   minikube
spark-spark-worker-6b9c48c564-24wgv        1/1       Running   0          8s        172.17.0.6   minikube
charts rporres(k8s: minikube) $ kubectl exec -it spark-spark-master-5b799fd6b6-gzngh env | grep SPARK
SPARK_DAEMON_MEMORY=1g
SPARK_NO_DAEMONIZE=yes
SPARK_SPARK_MASTER_PORT_7077_TCP_PROTO=tcp
SPARK_SPARK_MASTER_PORT_7077_TCP_ADDR=10.107.183.164
SPARK_SPARK_MASTER_PORT=tcp://10.107.183.164:7077
SPARK_SPARK_WEBUI_PORT_8080_TCP_ADDR=10.99.103.187
SPARK_SPARK_MASTER_SERVICE_HOST=10.107.183.164
SPARK_SPARK_WEBUI_PROXY_PORT_80_TCP_PROTO=tcp
SPARK_SPARK_WEBUI_PORT_8080_TCP_PROTO=tcp
SPARK_SPARK_WEBUI_PROXY_PORT_80_TCP_PORT=80
SPARK_SPARK_WEBUI_SERVICE_HOST=10.99.103.187
SPARK_SPARK_WEBUI_PORT=tcp://10.99.103.187:8080
SPARK_SPARK_WEBUI_PORT_8080_TCP_PORT=8080
SPARK_SPARK_WEBUI_PROXY_PORT=tcp://10.106.201.248:80
SPARK_SPARK_WEBUI_PORT_8080_TCP=tcp://10.99.103.187:8080
SPARK_SPARK_MASTER_PORT_7077_TCP_PORT=7077
SPARK_SPARK_MASTER_SERVICE_PORT=7077
SPARK_SPARK_WEBUI_PROXY_SERVICE_PORT=80
SPARK_SPARK_WEBUI_PROXY_PORT_80_TCP=tcp://10.106.201.248:80
SPARK_SPARK_WEBUI_PROXY_PORT_80_TCP_ADDR=10.106.201.248
SPARK_SPARK_WEBUI_SERVICE_PORT=8080
SPARK_SPARK_MASTER_PORT_7077_TCP=tcp://10.107.183.164:7077
SPARK_SPARK_WEBUI_PROXY_SERVICE_HOST=10.106.201.248
```
cc @r0mainK 