### PR TITLE
Add node selector and Volume

### DIFF
--- a/scylla/Chart.yaml
+++ b/scylla/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Scylla
 name: scylla
-version: 0.1.0
+version: 0.1.1
 home: https://www.scylladb.com/
 icon: https://www.scylladb.com/wp-content/uploads/logo-scylla.svg
 sources:

--- a/scylla/templates/scylla-statefulset.yaml
+++ b/scylla/templates/scylla-statefulset.yaml
@@ -20,6 +20,10 @@ spec:
         app: {{ template "scylla.name" . }} 
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
       containers:
       - name: {{ template "scylla.fullname" . }}
         image:  "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -57,10 +61,16 @@ spec:
           - name: scylla-ready-probe
             mountPath: /opt/ready-probe.sh
             subPath: ready-probe.sh
-      volumes: # TODO: data is discarded if pod restarts, change to something more persistant 
-        - name: scylla-data 
+      volumes:
+        - name: scylla-data
+          {{- if .Values.statefulset.hostPath }}
+          hostPath:
+            path: {{ .Values.statefulset.hostPath }}
+            type: ""
+          {{- else }}
           emptyDir:
             medium: "Memory"
+          {{- end }}
         - name: scylla-ready-probe
           configMap:
             name: {{ template "scylla.fullname" . }}


### PR DESCRIPTION
I added the node selector, the node defaults to `master-3` but can be set otherwise, and a volume can now be mounted for the scylla data instead of memory