### PR TITLE
Use the tcp network for control protocol

### DIFF
--- a/bblfsh-dashboard/Chart.yaml
+++ b/bblfsh-dashboard/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: bblfsh-dashboard
-version: 0.2.0
+version: 0.3.0
 description: |
     A web interface for Babelfish (https://doc.bblf.sh/).

--- a/bblfsh-dashboard/templates/deployment-using-external-bblfshd-server.yaml
+++ b/bblfsh-dashboard/templates/deployment-using-external-bblfshd-server.yaml
@@ -18,6 +18,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
         - -bblfsh-addr={{ .Values.settings.serverAddr }}
+        - -bblfshctl-addr={{ .Values.settings.serverCtlAddr }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
 {{- end }}

--- a/bblfsh-dashboard/templates/deployment-with-sidecar-bblfshd-container.yaml
+++ b/bblfsh-dashboard/templates/deployment-with-sidecar-bblfshd-container.yaml
@@ -30,12 +30,16 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
         - -bblfsh-addr=localhost:9432
+        - -bblfshctl-addr=localhost:9433
         resources:
 {{ toYaml .Values.resources | indent 10 }}
       - name: bblfshd
         image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
         imagePullPolicy: {{ .Values.server.image.pullPolicy }}
         {{- if .Values.server.drivers.install }}
+        args:
+        - -ctl-network=tcp
+        - -ctl-address=localhost:9433
         volumeMounts:
           - name: install-bblfshd-drivers-volume
             mountPath: /opt/install-bblfshd-drivers.sh

--- a/bblfsh-dashboard/templates/install-bblfshd-drivers-configmap.yaml
+++ b/bblfsh-dashboard/templates/install-bblfshd-drivers-configmap.yaml
@@ -8,6 +8,6 @@ metadata:
 data:
   install-bblfshd-drivers.sh: |
     {{- range $language, $driver := .Values.server.drivers.languages }}
-    bblfshctl driver install {{ $language }} {{ $driver.repository }}:{{ $driver.tag }}
+    bblfshctl driver install {{ $language }} {{ $driver.repository }}:{{ $driver.tag }} --ctl-endpoint=tcp --ctl-address=localhost:9433
     {{- end }}
 {{- end }}

--- a/bblfsh-dashboard/values.yaml
+++ b/bblfsh-dashboard/values.yaml
@@ -19,7 +19,9 @@ settings:
   ## will be deployed by this chart. This server is deployed as a container
   ## inside of the main pod, so if multiple replicas are configured multiple
   ## bblfsh servers will be deployed
+  ## serverCtlAddr will be used for control protocol if serverAddr is provided
   serverAddr:
+  serverCtlAddr:
 resources: {}
 
 # configuration for build-in server if, settings.serverAddr is empty.


### PR DESCRIPTION
caused by https://github.com/bblfsh/dashboard/pull/122/
required by https://github.com/src-d/issues-infrastructure/issues/150#issuecomment-387961280

Since https://github.com/bblfsh/dashboard/pull/122/ the `dashboard` will communicate with `bblfshd` using the tcp control network to retrieve the list of installed drivers. To do so, it is needed:

- `dashboard` backend needs to know what is the address of the tcp control network &rarr; [here](https://github.com/src-d/charts/pull/44/files#diff-259a96fa622cb6e771f1a7c3e82e577dR33),
- `bblfshd` needs to expose the control network using `tcp` under `9433` port &rarr; [here](https://github.com/src-d/charts/pull/44/files#diff-259a96fa622cb6e771f1a7c3e82e577dR40),
- `bblfshd` drivers needs to be installed using the new tcp control network &rarr; [here](https://github.com/src-d/charts/pull/44/files#diff-de8097ac0da2bd080c015a95154c4d8fR11).

### disclaimer

I did the following modifications on my own to satisfy the requirements given in the description :point_up: 
I'm not sure if it would be needed any other change, so help is welcomed :dancing_men: 