### PR TITLE
Update borges chart to use docker hub images

### DIFF
--- a/borges/Chart.yaml
+++ b/borges/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: borges
-version: 0.5.0
+version: 0.5.1

--- a/borges/README.md
+++ b/borges/README.md
@@ -5,7 +5,7 @@ This chart deploys [borges](https://github.com/src-d/borges)
 ## Pre-requisites
 
 - Kubernetes 1.4+
-- borges v0.16.2+
+- borges v0.17.0+
 
 ## Scope
 

--- a/borges/values.yaml
+++ b/borges/values.yaml
@@ -2,9 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 image:
-  repository: quay.io/srcd/borges
+  repository: srcd/borges
   # This value should be provided when releasing this chart
-  # tag: v0.16.2
+  # tag: v0.17.0
   pullPolicy: IfNotPresent
 consumer:
   workers: 12


### PR DESCRIPTION
We've changed the docker registry for borges from `quay.io` to Docker hub in the latest release `0.17.0`.