### PR TITLE
Add http health probes to lookout

### DIFF
--- a/lookout/Chart.yaml
+++ b/lookout/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: lookout
-version: 0.1.1
+version: 0.1.2

--- a/lookout/templates/dummy-analyzer-deployment.yaml
+++ b/lookout/templates/dummy-analyzer-deployment.yaml
@@ -31,16 +31,19 @@ spec:
               value: "ipv4://{{ template "lookout.fullname" . }}:{{ .Values.service.lookout.port }}"
             - name: LOOKOUT_ANALYZER
               value: "ipv4://0.0.0.0:{{ .Values.app.dummyAnalyzer.port }}"
+            - name: LOOKOUT_ANALYZER_PROBES_ADDRESS
+              value: "{{ .Values.app.dummyAnalyzer.probesAddr }}"
           ports:
             - containerPort: {{ .Values.app.dummyAnalyzer.port }}
               protocol: TCP
-          # TODO: These are bare-minimum probes. We should have something better
           livenessProbe:
-            tcpSocket:
-              port: {{ .Values.app.dummyAnalyzer.port }}
+            httpGet:
+              path: /health/liveness
+              port: {{ .Values.app.dummyAnalyzer.probesAddr }}
           readinessProbe:
-            tcpSocket:
-              port: {{ .Values.app.dummyAnalyzer.port }}
+            httpGet:
+              path: /health/readiness
+              port: {{ .Values.app.dummyAnalyzer.probesAddr }}
           resources:
 {{ toYaml .Values.resources.dummyAnalyzer | indent 12 }}
     {{- with .Values.nodeSelector.dummyAnalyzer }}

--- a/lookout/templates/lookout-deployment.yaml
+++ b/lookout/templates/lookout-deployment.yaml
@@ -71,19 +71,22 @@ spec:
             - name: LOOKOUT_GRPC_MAX_MSG_SIZE
               value: "{{ .Values.app.lookout.grpcMaxMsgSize }}"
             {{- end }}
+            - name: LOOKOUT_PROBES_ADDRESS
+              value: "{{ .Values.app.lookout.probesAddr }}"
           volumeMounts:
             - name: lookout-configuration-volume
               mountPath: /local/lookout
           ports:
             - containerPort: {{ .Values.app.lookout.port }}
               protocol: TCP
-          # TODO: These are bare-minimum probes. We should have something better
           livenessProbe:
-            tcpSocket:
-              port: {{ .Values.app.lookout.port }}
+            httpGet:
+              path: /health/liveness
+              port: {{ .Values.app.lookout.probesAddr }}
           readinessProbe:
-            tcpSocket:
-              port: {{ .Values.app.lookout.port }}
+            httpGet:
+              path: /health/readiness
+              port: {{ .Values.app.lookout.probesAddr }}
           resources:
 {{ toYaml .Values.resources.lookout | indent 12 }}
     {{- with .Values.nodeSelector.lookout }}

--- a/lookout/values.yaml
+++ b/lookout/values.yaml
@@ -32,6 +32,7 @@ app:
     repository: github.com/src-d/lookout
     logFormat: json
     logLevel: info
+    probesAddr: 0.0.0.0:8090
   # dbConnectionString: postgres://lookout:lookout@postgres-postgresql:5432/lookout?sslmode=disable
   # bblfshdConnectionString: ipv4://bblfshd-bblfshd:9432
   # secretName:
@@ -40,6 +41,7 @@ app:
   #   githubToken: token
   dummyAnalyzer:
     port: 10302
+    probesAddr: 0.0.0.0:8091
 
 
 resources:


### PR DESCRIPTION
Part of https://github.com/src-d/lookout/issues/180.
Depends on https://github.com/src-d/lookout/pull/252.