### PR TITLE
Fix lookout probes ports

### DIFF
--- a/lookout/Chart.yaml
+++ b/lookout/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: lookout
-version: 0.1.2
+version: 0.1.3

--- a/lookout/templates/dummy-analyzer-deployment.yaml
+++ b/lookout/templates/dummy-analyzer-deployment.yaml
@@ -32,18 +32,18 @@ spec:
             - name: LOOKOUT_ANALYZER
               value: "ipv4://0.0.0.0:{{ .Values.app.dummyAnalyzer.port }}"
             - name: LOOKOUT_ANALYZER_PROBES_ADDRESS
-              value: "{{ .Values.app.dummyAnalyzer.probesAddr }}"
+              value: "0.0.0.0:{{ .Values.app.dummyAnalyzer.probesPort }}"
           ports:
             - containerPort: {{ .Values.app.dummyAnalyzer.port }}
               protocol: TCP
           livenessProbe:
             httpGet:
               path: /health/liveness
-              port: {{ .Values.app.dummyAnalyzer.probesAddr }}
+              port: {{ .Values.app.dummyAnalyzer.probesPort }}
           readinessProbe:
             httpGet:
               path: /health/readiness
-              port: {{ .Values.app.dummyAnalyzer.probesAddr }}
+              port: {{ .Values.app.dummyAnalyzer.probesPort }}
           resources:
 {{ toYaml .Values.resources.dummyAnalyzer | indent 12 }}
     {{- with .Values.nodeSelector.dummyAnalyzer }}

--- a/lookout/templates/lookout-deployment.yaml
+++ b/lookout/templates/lookout-deployment.yaml
@@ -72,7 +72,7 @@ spec:
               value: "{{ .Values.app.lookout.grpcMaxMsgSize }}"
             {{- end }}
             - name: LOOKOUT_PROBES_ADDRESS
-              value: "{{ .Values.app.lookout.probesAddr }}"
+              value: "0.0.0.0:{{ .Values.app.lookout.probesPort }}"
           volumeMounts:
             - name: lookout-configuration-volume
               mountPath: /local/lookout
@@ -82,11 +82,11 @@ spec:
           livenessProbe:
             httpGet:
               path: /health/liveness
-              port: {{ .Values.app.lookout.probesAddr }}
+              port: {{ .Values.app.lookout.probesPort }}
           readinessProbe:
             httpGet:
               path: /health/readiness
-              port: {{ .Values.app.lookout.probesAddr }}
+              port: {{ .Values.app.lookout.probesPort }}
           resources:
 {{ toYaml .Values.resources.lookout | indent 12 }}
     {{- with .Values.nodeSelector.lookout }}

--- a/lookout/values.yaml
+++ b/lookout/values.yaml
@@ -32,7 +32,7 @@ app:
     repository: github.com/src-d/lookout
     logFormat: json
     logLevel: info
-    probesAddr: 0.0.0.0:8090
+    probesPort: 8090
   # dbConnectionString: postgres://lookout:lookout@postgres-postgresql:5432/lookout?sslmode=disable
   # bblfshdConnectionString: ipv4://bblfshd-bblfshd:9432
   # secretName:
@@ -41,7 +41,7 @@ app:
   #   githubToken: token
   dummyAnalyzer:
     port: 10302
-    probesAddr: 0.0.0.0:8091
+    probesPort: 8091
 
 
 resources:


### PR DESCRIPTION
In PR #72 I mixed address with port, and now [the deployments fail](https://drone.srcd.host/src-d/lookout/175) with:

```
Error: UPGRADE FAILED: Deployment.extensions "lookout-dummy-analyzer" is invalid: [spec.template.spec.containers[0].livenessProbe.httpGet.port: Invalid value: "0.0.0.0:8091": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-), spec.template.spec.containers[0].livenessProbe.httpGet.port: Invalid value: "0.0.0.0:8091": must contain at least one letter or number (a-z, 0-9), spec.template.spec.containers[0].readinessProbe.httpGet.port: Invalid value: "0.0.0.0:8091": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-), spec.template.spec.containers[0].readinessProbe.httpGet.port: Invalid value: "0.0.0.0:8091": must contain at least one letter or number (a-z, 0-9)] && Deployment.extensions "lookout" is invalid: [spec.template.spec.containers[0].livenessProbe.httpGet.port: Invalid value: "0.0.0.0:8090": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-), spec.template.spec.containers[0].livenessProbe.httpGet.port: Invalid value: "0.0.0.0:8090": must contain at least one letter or number (a-z, 0-9), spec.template.spec.containers[0].readinessProbe.httpGet.port: Invalid value: "0.0.0.0:8090": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-), spec.template.spec.containers[0].readinessProbe.httpGet.port: Invalid value: "0.0.0.0:8090": must contain at least one letter or number (a-z, 0-9)]
Error running helm command: upgrade --install lookout srcd-charts/lookout --set image.lookout.tag=commit-8c8ea9f --values .helm-staging.yml --tiller-namespace kube-system
```