### PR TITLE
Fix lookout chart syntax

### DIFF
--- a/lookout/Chart.yaml
+++ b/lookout/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: lookout
-version: 0.2.0
+version: 0.2.1

--- a/lookout/templates/lookout-deployment.yaml
+++ b/lookout/templates/lookout-deployment.yaml
@@ -32,10 +32,10 @@ spec:
         {{- if .Values.providers.github.secretName }}
         - name: lookout-github-key-volume
           secret:
-            secretName: {{ Values.providers.github.secretName }}
+            secretName: {{ .Values.providers.github.secretName }}
             items:
-              - key:  {{ required "Missing providers.github.private_key" Values.providers.github.private_key }}
-                path: {{ required "Missing providers.github.private_key"  Values.providers.github.private_key }}
+              - key:  {{ required "Missing providers.github.private_key" .Values.providers.github.private_key }}
+                path: {{ required "Missing providers.github.private_key"  .Values.providers.github.private_key }}
         {{- end }}
       containers:
         - name: lookout


### PR DESCRIPTION
Latest lookout deployment failed (https://drone.srcd.host/src-d/lookout/215), apparently the changes in https://github.com/src-d/charts/pull/79 use `Values` instead of `.Values`.