### PR TITLE
Keep history of old charts on GH Pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,6 @@ deploy:
   skip_cleanup: true
   local_dir: repository
   github_token: $GITHUB_TOKEN
+  keep-history: true
   on:
     branch: master


### PR DESCRIPTION
Travis deployment option for GitHub pages: `keep-history: Optional, create incremental commit instead of doing push force, defaults to false.`