### PR TITLE
[Do not merge][gitbase-web] use ClusterIP on port 80 by default

### DIFF
--- a/gitbase-web/Chart.yaml
+++ b/gitbase-web/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: gitbase-web
-version: 0.1.8
+version: 0.2.0

--- a/gitbase-web/values.yaml
+++ b/gitbase-web/values.yaml
@@ -5,8 +5,8 @@
 replicaCount: 1
 
 service:
-  type: NodePort
-  port: 8080
+  type: ClusterIP
+  port: 80
   internalPort: 8080
 
 ingress:


### PR DESCRIPTION
- Change default service type from NodePort to ClusterIP, which is the
default ServiceType in Kubernetes.
- Change default port from 8080 to 80 which, being the standard, is more
intuitive. There is no point in using 8080 when we have a dedicated
virtual IP.

Signed-off-by: Santiago M. Mola <santi@mola.io>