### PR TITLE
[gitbase-web] use gitbaseServer.host instead of .address

### DIFF
--- a/gitbase-web/Chart.yaml
+++ b/gitbase-web/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: gitbase-web
-version: 0.2.1
+version: 0.4.0

--- a/gitbase-web/templates/deployment.yaml
+++ b/gitbase-web/templates/deployment.yaml
@@ -5,7 +5,7 @@
 {{- $port := default "3306" .Values.settings.gitbaseServer.port -}}
 {{- $user := default "gitbase" .Values.settings.gitbaseServer.user -}}
 {{- $database := default "none" .Values.settings.gitbaseServer.database -}}
-{{- $address := required "Missing settings.gitbaseServer.address" .Values.settings.gitbaseServer.address -}}
+{{- $host := required "Missing settings.gitbaseServer.host" .Values.settings.gitbaseServer.host -}}
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
@@ -38,9 +38,9 @@ spec:
               value: "{{ .Values.settings.gitbaseWebEnv }}"
             - name: GITBASEPG_DB_CONNECTION
             {{- if .Values.settings.gitbaseServer.password }}
-              value: {{ printf "%s:%s@tcp(%s:%s)/%s?maxAllowedPacket=%s" $user .Values.settings.gitbaseServer.password $address $port $database .Values.gitbaseWeb.gitbaseMaxAllowedPacket }}
+              value: {{ printf "%s:%s@tcp(%s:%s)/%s?maxAllowedPacket=%s" $user .Values.settings.gitbaseServer.password $host $port $database .Values.gitbaseWeb.gitbaseMaxAllowedPacket }}
             {{- else }}
-              value: {{ printf "%s@tcp(%s:%s)/%s?maxAllowedPacket=%s" $user $address $port $database .Values.gitbaseWeb.gitbaseMaxAllowedPacket }}
+              value: {{ printf "%s@tcp(%s:%s)/%s?maxAllowedPacket=%s" $user $host $port $database .Values.gitbaseWeb.gitbaseMaxAllowedPacket }}
             {{- end }}
             - name: GITBASEPG_BBLFSH_SERVER_URL
               value: "{{ .Values.settings.bblfshdServer.address }}:{{ default "9432" .Values.settings.bblfshdServer.port }}"

--- a/gitbase-web/values.yaml
+++ b/gitbase-web/values.yaml
@@ -25,10 +25,12 @@ settings: {}
   # This specifies an external bblfshd server
   # Requires settings.gitbaseServer to be set
   #bblfshdServer:
-  
+  #  address: bblfshd:9432
+
   # This specifies an external gitbase server
   # Requires settings.bblfshdServer to be set
   #gitbaseServer:
+  #  host: gitbase
 
 gitbaseWeb:
   gitbaseMaxAllowedPacket: "4194304"


### PR DESCRIPTION
- Renamed gitbaseServer.address to gitbaseServer.host
- Added comments to values.yaml with usage examples.

Only host (no host:port) is expected on gitbaseServer.host. This was
previously not clear.

Signed-off-by: Santiago M. Mola <santi@mola.io>