### PR TITLE
[gitbase-web] use default ingress template (Helm 2.11.0)

### DIFF
--- a/gitbase-web/Chart.yaml
+++ b/gitbase-web/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: gitbase-web
-version: 0.4.0
+version: 0.5.0

--- a/gitbase-web/templates/ingress.yaml
+++ b/gitbase-web/templates/ingress.yaml
@@ -1,32 +1,39 @@
 {{- if .Values.ingress.enabled -}}
-{{- $serviceName := include "gitbase-web.fullname" . -}}
+{{- $fullName := include "gitbase-web.fullname" . -}}
+{{- $ingressPath := .Values.ingress.path -}}
 {{- $servicePort := .Values.service.port -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "gitbase-web.fullname" . }}
+  name: {{ $fullName }}
   labels:
-    app: {{ template "gitbase-web.name" . }}
-    chart: {{ template "gitbase-web.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "gitbase-web.name" . }}
+    helm.sh/chart: {{ include "gitbase-web.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
   annotations:
-    {{- range $key, $value := .Values.ingress.annotations }}
-      {{ $key }}: {{ $value | quote }}
-    {{- end }}
-      kubernetes.io/ingress.global-static-ip-name: {{ required "Static IP is missing" .Values.ingress.globalStaticIpName }}
-
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
   rules:
-    - host: {{ required "Hostname is missing" .Values.ingress.hostname }}
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
       http:
         paths:
-          - path: /*
+          - path: {{ $ingressPath }}
             backend:
-              serviceName: {{ $serviceName }}
+              serviceName: {{ $fullName }}
               servicePort: {{ $servicePort }}
-  tls:
-    - secretName: {{ .Values.ingress.hostname | replace "." "-" }}-tls
-      hosts:
-        - {{ .Values.ingress.hostname }}
+  {{- end }}
 {{- end }}

--- a/gitbase-web/templates/ingress.yaml
+++ b/gitbase-web/templates/ingress.yaml
@@ -7,10 +7,10 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-    app.kubernetes.io/name: {{ include "gitbase-web.name" . }}
-    helm.sh/chart: {{ include "gitbase-web.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app: {{ include "gitbase-web.name" . }}
+    chart: {{ include "gitbase-web.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/gitbase-web/values.yaml
+++ b/gitbase-web/values.yaml
@@ -10,16 +10,17 @@ service:
   internalPort: 8080
 
 ingress:
-  enabled: true
-  # globalStaticIpName must be received as a parameter
-  # hostname must be received as a parameter
-  # hosts defined in templates/ingress.yml. Do not override here.
-  annotations:
-    kubernetes.io/ingress.class: gce
-    kubernetes.io/tls-acme: "true"
-    # kubernetes.io/ingress.global-static-ip-name is defined in templates/ingress.yml. Do not override here.
-  tls: true
-    # secretName and hosts are defined in templates/ingress.yml. Do not override here.
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
 
 settings: {}
   # This specifies an external bblfshd server


### PR DESCRIPTION
- Change ingress.yaml to match latest Helm (2.11.0) template as much as
possible.
- This allows setting multiple hosts and does not assume a particular
ingress controller.

Signed-off-by: Santiago M. Mola <santi@mola.io>