### PR TITLE
[bblfsh-web] use ClusterIP by default

### DIFF
--- a/bblfsh-web/Chart.yaml
+++ b/bblfsh-web/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: bblfsh-web
-version: 0.6.1
+version: 0.7.0
 description: |
     A web interface for Babelfish (https://doc.bblf.sh/).

--- a/bblfsh-web/templates/deployment.yaml
+++ b/bblfsh-web/templates/deployment.yaml
@@ -28,6 +28,10 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
         - -bblfsh-addr={{ default "localhost:9432" .Values.settings.serverAddr }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.service.internalPort }}
+          protocol: TCP
         resources:
 {{ toYaml .Values.resources | indent 10 }}
     {{- with .Values.nodeSelector }}

--- a/bblfsh-web/templates/service.yaml
+++ b/bblfsh-web/templates/service.yaml
@@ -11,7 +11,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.targetPort }}
+      targetPort: http
       protocol: TCP
       name: http
   selector:

--- a/bblfsh-web/values.yaml
+++ b/bblfsh-web/values.yaml
@@ -9,9 +9,9 @@ image:
   pullPolicy: IfNotPresent
 
 service:
-  type: NodePort
+  type: ClusterIP
   port: 80
-  targetPort: 8080
+  internalPort: 8080
 
 ingress:
   enabled: true


### PR DESCRIPTION
- Use ClusterIP by default.
- Move to service.port/internalPort, for consistency with gitbase-web.
Also closer to official charts.

Signed-off-by: Santiago M. Mola <santi@mola.io>