### PR TITLE
Add missing labels to bblfsh-web deployment

### DIFF
--- a/bblfsh-web/templates/deployment.yaml
+++ b/bblfsh-web/templates/deployment.yaml
@@ -3,13 +3,17 @@ kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
   labels:
+    app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
       labels:
         app: {{ template "fullname" . }}
+        release: {{ .Release.Name }}
     spec:
       volumes:
 {{- if not .Values.settings.serverAddr }}


### PR DESCRIPTION
These were missing thus the service which had the more labels in the selector could not find the deployment