### PR TITLE
AntiAffinityRules for bblsfsh-web

### DIFF
--- a/bblfsh-web/Chart.yaml
+++ b/bblfsh-web/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: bblfsh-web
-version: 0.7.0
+version: 0.7.1
 description: |
     A web interface for Babelfish (https://doc.bblf.sh/).

--- a/bblfsh-web/Chart.yaml
+++ b/bblfsh-web/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: bblfsh-web
-version: 0.7.1
+version: 0.8.0
 description: |
     A web interface for Babelfish (https://doc.bblf.sh/).

--- a/bblfsh-web/templates/deployment.yaml
+++ b/bblfsh-web/templates/deployment.yaml
@@ -38,3 +38,19 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
+
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end}}
+{{- if .Values.antiAffinityEnabled }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+             matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - {{ template "fullname" . }}
+            topologyKey: kubernetes.io/hostname
+{{- end }}

--- a/bblfsh-web/templates/deployment.yaml
+++ b/bblfsh-web/templates/deployment.yaml
@@ -38,19 +38,7 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-
     {{- with .Values.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}
     {{- end}}
-{{- if .Values.antiAffinityEnabled }}
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-             matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - {{ template "fullname" . }}
-            topologyKey: kubernetes.io/hostname
-{{- end }}

--- a/bblfsh-web/templates/deployment.yaml
+++ b/bblfsh-web/templates/deployment.yaml
@@ -42,3 +42,4 @@ spec:
       affinity:
 {{ toYaml . | indent 8 }}
     {{- end}}
+

--- a/bblfsh-web/values.yaml
+++ b/bblfsh-web/values.yaml
@@ -13,6 +13,8 @@ service:
   port: 80
   internalPort: 8080
 
+antiAffinityEnabled: true
+
 ingress:
   enabled: true
   # globalStaticIpName must be received as a parameter

--- a/bblfsh-web/values.yaml
+++ b/bblfsh-web/values.yaml
@@ -13,8 +13,6 @@ service:
   port: 80
   internalPort: 8080
 
-antiAffinityEnabled: true
-
 ingress:
   enabled: true
   # globalStaticIpName must be received as a parameter

--- a/bblfsh-web/values.yaml
+++ b/bblfsh-web/values.yaml
@@ -39,6 +39,8 @@ resources: {}
 
 nodeSelector: {}
 
+affinity: {}
+
 # configuration for build-in server if, settings.serverAddr is empty.
 server:
   image:


### PR DESCRIPTION
The idea is to have the web services pods running on different pods as suggested by @rporres in [src-d/infrastructure#201] (https://github.com/src-d/infrastructure/issues/201)

First idea is to use a default value to enable/disable the location constraint.
```
antiAffinityEnabled: true
```

Tested in development with bblfsh-web and working as expected. With just one node in the cluster the second pod is not deployed as one of them is already deployed in the node. 

If a second node is added to the cluster, both pods are allocated one in each node.

Signed-off-by: David Riosalido <driosalido@gmail.com>