### PR TITLE
Fix incorrect repository name for kubernetes-local-pv-provisioner

### DIFF
--- a/kubernetes-local-pv-provisioner/Chart.yaml
+++ b/kubernetes-local-pv-provisioner/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for kubernetes-local-pv-provisioner
 name: kubernetes-local-pv-provisioner
-version: 0.1.0
+version: 0.1.1

--- a/kubernetes-local-pv-provisioner/values.yaml
+++ b/kubernetes-local-pv-provisioner/values.yaml
@@ -1,6 +1,6 @@
 # Default values for kubernetes-local-pv-provisioner
 image:
-  repository: src-d/kubernetes-local-pv-provisioner
+  repository: srcd/kubernetes-local-pv-provisioner
   # tag: latest
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Signed-off-by: Maartje Eyskens <maartje@eyskens.me>