### PR TITLE
Remove api-proxy by default

### DIFF
--- a/spark/Chart.yaml
+++ b/spark/Chart.yaml
@@ -16,7 +16,7 @@
 # https://github.com/kubernetes/charts/tree/master/stable/spark
 
 name: spark
-version: 0.6.0
+version: 0.7.0
 description: Fast and general-purpose cluster computing system.
 home: http://spark.apache.org
 icon: http://spark.apache.org/images/spark-logo-trademark.png

--- a/spark/README.md
+++ b/spark/README.md
@@ -67,11 +67,11 @@ The following tables lists the configurable parameters of the Spark chart and th
 | `WebUiProxy.ServicePort`            | k8s service port                     | `80`                                                       |
 | `WebUiProxy.ContainerPort`          | Container listening port             | `80`                                                       |
 | `WebUiProxy.NodeSelector`           | WebUiProxy k8s node selector         | `{}`                                                       |
-| `WebUiProxy.ReverseProxy.Deploy`    | WebUiProxy is behind a reverse proxy | `yes` (we assume it will be kube-proxy)                    |
-| `WebUiProxy.ReverseProxy.ApiPrefix` | api-prefix to pass to kube proxy     | `spark-ui-proxy` (we assume it will be kube-proxy)         |
-| `WebUiProxy.ReverseProxy.Debug`     | Print debug messages                 | `false` (we assume it will be kube-proxy)                  |
+| `WebUiProxy.ReverseProxy.Deploy`    | WebUiProxy is behind a reverse proxy | `yes`                                                      |
+| `WebUiProxy.ReverseProxy.ApiPrefix` | api-prefix to pass to kube proxy     |                                                            |
+| `WebUiProxy.ReverseProxy.Debug`     | Print debug messages                 | `false`                                                    |
 
-We need the api prefix in order to avoid namespace clashing, as `spark-ui-proxy` rewrites paths under `/api/v1` which is what kube-proxy uses. Hence, in order for this integration to work properly, kube-proxy must be started with `--api-prefix` option
+If you're using `kubectl proxy` as your reverse proxy, it's important that you set the `ApiPrefix` property, since we need it in order to avoid namespace clashing, as `spark-ui-proxy` rewrites paths under `/api/v1` which is what `kubectl proxy` uses. Hence, in order for this integration to work properly, kube-proxy must be started with `--api-prefix` option
 
 ```
 $ kubectl proxy --api-prefix=/spark-ui-proxy

--- a/spark/templates/spark-webui-proxy-deployment.yaml
+++ b/spark/templates/spark-webui-proxy-deployment.yaml
@@ -43,8 +43,10 @@ spec:
           env:
             - name: REVERSE_PROXY
               value: "yes"
+            {{- if .Values.WebUiProxy.ReverseProxy.ApiPrefix }}
             - name: URL_PREFIX
               value: "/{{ .Values.WebUiProxy.ReverseProxy.ApiPrefix }}/api/v1/namespaces/{{ .Release.Namespace }}/services/{{ template "webui-proxy-fullname" . }}:{{ .Values.WebUiProxy.ServicePort }}/proxy"
+            {{- end }}
             {{- if .Values.WebUiProxy.ReverseProxy.Debug }}
             - name: DEBUG
               value: "yes"

--- a/spark/values.yaml
+++ b/spark/values.yaml
@@ -42,8 +42,10 @@ WebUiProxy:
   Cpu: "100m"
   ReverseProxy:
     Deploy: true
-    ApiPrefix: spark-ui-proxy
     Debug: false
+    # This will make spark-web-ui-proxy work with kubectl proxy --api-prefix
+    # which is something that always should be set when working when kubectl proxy
+    # ApiPrefix: spark-ui-proxy
   #NodeSelector:
     #srcd.host/type: worker
 


### PR DESCRIPTION
It can now be enabled via `WebUiProxy.ReverseProxy.ApiPrefix`

This is a breaking change... But it makes much more sense to make it this way...

Signed-off-by: Rafael Porres Molina <rafa@sourced.tech>