### PR TITLE
Added endpoints

### DIFF
--- a/prometheus-external-monitor/Chart.yaml
+++ b/prometheus-external-monitor/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for external ServiceMonitor entries
 name: prometheus-external-monitor
-version: 0.1.0
+version: 0.2.0

--- a/prometheus-external-monitor/templates/endpoint.yaml
+++ b/prometheus-external-monitor/templates/endpoint.yaml
@@ -18,3 +18,4 @@ subsets:
     port: {{ .port | default "9100" }}
     protocol: TCP
 {{- end }}
+

--- a/prometheus-external-monitor/templates/endpoint.yaml
+++ b/prometheus-external-monitor/templates/endpoint.yaml
@@ -2,7 +2,7 @@
 {{- range .Values.endpoints }}
 ---
 apiVersion: v1
-kind: Service
+kind: Endpoints
 metadata:
   name: {{ template "prometheus-external-monitor.fullname" $root }}-{{ .name }}
   labels:
@@ -10,13 +10,11 @@ metadata:
     chart: {{ template "prometheus-external-monitor.chart" $root }}
     release: {{ $root.Release.Name }}
     heritage: {{ $root.Release.Service }}
-spec:
-  type: ExternalName
-  externalName: {{ .ip }}
-  clusterIP: ""
-  ports:
-    - name: metrics
-      port: {{ .port | default "9100" }}
-      protocol: TCP
-      targetPort:  {{ .port | default "9100" }}
+subsets:
+- addresses: 
+  - ip: {{ .ip }}
+  ports: 
+  - name: metrics
+    port: {{ .port | default "9100" }}
+    protocol: TCP
 {{- end }}

--- a/prometheus-external-monitor/templates/service.yaml
+++ b/prometheus-external-monitor/templates/service.yaml
@@ -12,7 +12,7 @@ metadata:
     heritage: {{ $root.Release.Service }}
 spec:
   type: ExternalName
-  externalName: {{ .ip }}
+  externalName: {{ .hostname }}
   clusterIP: ""
   ports:
     - name: metrics

--- a/prometheus-external-monitor/values.yaml
+++ b/prometheus-external-monitor/values.yaml
@@ -1,6 +1,7 @@
 endpoints: []
 # - name: server-1
 #   hostname: server-1.full.domain.tld
+#   ip: 192.168.0.1 
 #   port: 9100
 #   path: /metrics
 serviceMonitor:


### PR DESCRIPTION
ExternalName Service is not enough to get scrapped, and endpoint is also needed. 

Also the full hostname is resolved to the public address and the node-exporter is only listening in the internal, so I've added the IP to the set of values that has to be provided in the values. 