### PR TITLE
Refactor website redirect chart to support multiple entries

### DIFF
--- a/website-redirect/Chart.yaml
+++ b/website-redirect/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to redirect all requests to another URL
 name: website-redirect
-version: 0.3.1
+version: 1.0.0

--- a/website-redirect/templates/caddy-configmap.yaml
+++ b/website-redirect/templates/caddy-configmap.yaml
@@ -15,7 +15,7 @@ data:
 
     {{- range $redirect := .Values.redirects }}
     {{ required "Hostname is missing" $redirect.hostname }}:80 {
-      redir / {{ required "To is missing" $redirect.to }}{{ if $redirect.withPath }}{uri}{{ end }} 301
+      redir / {{ required "To is missing" $redirect.to }}{{ if $redirect.preservePath }}{uri}{{ end }} 301
     }
     {{- end }}
 

--- a/website-redirect/templates/caddy-configmap.yaml
+++ b/website-redirect/templates/caddy-configmap.yaml
@@ -1,3 +1,6 @@
+{{- if empty .Values.redirects }}
+{{- fail "You have to either set at least one redirect in redirects" }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,7 +13,9 @@ data:
       status 200 /health
     }
 
-    :80 {
-      redir / {{ required "missing redirect.to" .Values.redirect.to }}{{ if .Values.redirect.withPath }}{uri}{{ end }} 301
+    {{- range $redirect := .Values.redirects }}
+    {{ required "Hostname is missing" $redirect.hostname }}:80 {
+      redir / {{ required "To is missing" $redirect.to }}{{ if $redirect.withPath }}{uri}{{ end }} 301
     }
+    {{- end }}
 

--- a/website-redirect/templates/ingress.yaml
+++ b/website-redirect/templates/ingress.yaml
@@ -18,15 +18,19 @@ metadata:
 
 spec:
   rules:
-    - host: {{ required "Hostname is missing" .Values.ingress.hostname }}
+    {{- range $redirect := .Values.redirects }}
+    - host: {{ required "Hostname is missing" $redirect.hostname }}
       http:
         paths:
           - path: /*
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
+    {{- end }}
   tls:
-    - secretName: {{ .Values.ingress.hostname | replace "." "-" }}-tls
+  {{- range $redirect := .Values.redirects }}
+    - secretName: {{ $redirect.hostname | replace "." "-" }}-tls
       hosts:
-        - {{ .Values.ingress.hostname }}
+        - {{ $redirect.hostname }}
+  {{- end }}
 {{- end }}

--- a/website-redirect/values.yaml
+++ b/website-redirect/values.yaml
@@ -11,7 +11,7 @@ image:
 
 redirects: []
   # - to: 
-  #   withPath: false
+  #   preservePath: false
   #   hostname: 
 
 service:

--- a/website-redirect/values.yaml
+++ b/website-redirect/values.yaml
@@ -9,9 +9,10 @@ image:
   tag: 0.11.0
   pullPolicy: IfNotPresent
 
-redirect:
-  # to: 
-  withPath: false
+redirects: []
+  # - to: 
+  #   withPath: false
+  #   hostname: 
 
 service:
   # NodePort is needed to work properly with default ingress
@@ -21,7 +22,6 @@ service:
 ingress:
   enabled: true
   # globalStaticIpName must be received as a parameter
-  # hostname must be received as a parameter
   # hosts defined in templates/ingress.yml. Do not override here.
   annotations:
     kubernetes.io/ingress.class: gce


### PR DESCRIPTION
This is a breaking change for the website-redirect chart that allows for multiple
entries in one install of the chart.
redirects accepts multiple entries in an array that configure the server
to serve multiple virtual hosts with different redirects.
This as well sets up the ingress (with TLS) for all entered hostnames.

Signed-off-by: Maartje Eyskens <maartje@eyskens.me>