### PR TITLE
Fix repo sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ go:
 - "1.12.x"
 
 stages:
+  - name: lint
+  - name: tests
   - name: repo-sync
     if: branch = master AND type = push
 
@@ -32,7 +34,7 @@ jobs:
         - cd .. # ct is having issues when processing charts on the root
         - ct lint --all --config charts/ct.yaml # --all is being used as our project structure doesn't allow propper git change detection
     - name: Tests
-      stage: Tests
+      stage: tests
       env:
         - CHANGE_MINIKUBE_NONE_USER=true # makes sure config files are owned by the travis user
         - KUBERNETES_VERSION=v1.14.0

--- a/scripts/repo-sync.sh
+++ b/scripts/repo-sync.sh
@@ -27,7 +27,7 @@ git config user.name "Infra sourced{d}"
 mv index.yaml "$index_dir/index.yaml"
 popd
 
-for dir in $(ls | grep -v scripts | grep -v docs); do
+for dir in $(ls | grep -vE '^scripts$|^docs$'); do
     [ -d "$dir" ] || continue
     if helm dependency build "$dir"; then
         helm package --destination "$packages_dir" "$dir"

--- a/scripts/repo-sync.sh
+++ b/scripts/repo-sync.sh
@@ -27,7 +27,7 @@ git config user.name "Infra sourced{d}"
 mv index.yaml "$index_dir/index.yaml"
 popd
 
-for dir in $(ls | grep -v scripts); do
+for dir in $(ls | grep -v scripts | grep -v docs); do
     [ -d "$dir" ] || continue
     if helm dependency build "$dir"; then
         helm package --destination "$packages_dir" "$dir"


### PR DESCRIPTION
This should fix the repo-sync step by excluding the docs folder.
It also patches the Travis file to only do the sync after the charts got tested

Signed-off-by: Maartje Eyskens <maartje@eyskens.me>