### PR TITLE
Fix linting and test issues in ghost backup chart

### DIFF
--- a/ghost-gcs-backup/ci/test-values.yaml
+++ b/ghost-gcs-backup/ci/test-values.yaml
@@ -1,0 +1,3 @@
+app:
+  ghostAPIKey: xxx
+  ghostEndpoint: https://sourced.ghost.io

--- a/ghost-gcs-backup/templates/cronjob.yaml
+++ b/ghost-gcs-backup/templates/cronjob.yaml
@@ -32,10 +32,9 @@ spec:
               value: "{{ required "Missing app.ghostEndpoint" .Values.app.ghostEndpoint }}"
             - name: GHOST_API_KEY
               valueFrom:
-                  secretKeyRef:
-                    name: {{ default (include "ghost-gcs-backup.fullname" .) .Values.app.ghostAPIKeySecretName }}
-                    key: api_key
-              value: "{{ required "Missing app.ghostAPIKey" .Values.app.ghostAPIKey }}"
+                secretKeyRef:
+                  name: {{ default (include "ghost-gcs-backup.fullname" .) .Values.app.ghostAPIKeySecretName }}
+                  key: api_key
             {{- if .Values.googleApplicationCredentialsSecret.enabled }}
             volumeMounts:
             - mountPath: /var/secrets/google

--- a/ghost-gcs-backup/values.yaml
+++ b/ghost-gcs-backup/values.yaml
@@ -7,7 +7,7 @@ image:
   tag: v0.0.1
   pullPolicy: IfNotPresent
 
-app: 
+app:
   ghostPostLimit: 1000
 # ghostEndpoint: https://sourced.ghost.io
 # ghostAPIKey:


### PR DESCRIPTION
* Added test values to make chart install
* Fixed linting issues
* Removed value key from ghost api key as it was already managed
  through a secret and it was making tests fail

Signed-off-by: Rafael Porres Molina <rafa@sourced.tech>