### PR TITLE
Fix spark 233

### DIFF
--- a/spark/Chart.yaml
+++ b/spark/Chart.yaml
@@ -17,7 +17,7 @@
 
 apiVersion: v1
 name: spark
-version: 1.0.5
+version: 1.1.0
 appVersion: 2.2.0
 description: Fast and general-purpose cluster computing system.
 home: http://spark.apache.org

--- a/spark/Chart.yaml
+++ b/spark/Chart.yaml
@@ -17,7 +17,7 @@
 
 apiVersion: v1
 name: spark
-version: 1.0.4
+version: 1.0.5
 appVersion: 2.2.0
 description: Fast and general-purpose cluster computing system.
 home: http://spark.apache.org

--- a/spark/templates/spark-master-deployment.yaml
+++ b/spark/templates/spark-master-deployment.yaml
@@ -25,6 +25,7 @@ spec:
         release: {{ .Release.Name | quote }}
         component: "{{ .Release.Name }}-spark-master"
     spec:
+      hostname: {{ template "master-fullname" . }}
       volumes:
       {{- with .Values.master.additionalVolumes  }}
 {{ toYaml . | indent 8 }}
@@ -43,7 +44,7 @@ spec:
             - -c
             - |
               echo $(hostname -i) {{ template "master-fullname" . }} >> /etc/hosts
-              /opt/spark/sbin/start-master.sh --host {{ template "master-fullname" . }} --port 7077 --webui-port 8080
+              /opt/spark/sbin/start-master.sh
           ports:
             - name: master
               containerPort: 7077
@@ -60,12 +61,18 @@ spec:
             value: {{ default "1g" .Values.master.daemonMemory | quote }}
           - name: SPARK_NO_DAEMONIZE
             value: "yes"
+          - name: SPARK_MASTER_PORT
+            value: "7077"
+          - name: SPARK_MASTER_HOST
+            value: "{{ template "master-fullname" . }}"
+          - name: SPARK_MASTER_WEBUI_PORT
+            value: "8080"
           {{- with .Values.master.extraEnv  }}
 {{ toYaml . | indent 10 }}
           {{- end }}
       {{- if .Values.livy.enabled }}
         - name : {{ template "livy-fullname" . }}
-          image: "{{ default "srcd/spark-livy" .Values.livy.image }}:{{ default "2.2.3" .Values.livy.ImageTag }}"
+          image: "{{ default "srcd/spark-livy" .Values.livy.image }}:{{ default "2.2.3" .Values.livy.imageTag }}"
           ports:
             - name: livy
               containerPort: 8998

--- a/spark/templates/spark-master-service.yaml
+++ b/spark/templates/spark-master-service.yaml
@@ -8,14 +8,12 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: "{{ .Release.Name }}-spark-master"
 spec:
-  type: {{ .Values.master.service.type }}
+  type: ClusterIP
+  clusterIP: None
   ports:
     - port: {{ .Values.master.service.port }}
       targetPort: master
       protocol: TCP
       name: master
-      {{- if .Values.master.service.nodePort }}
-      nodePort: {{ .Values.master.service.nodePort }}
-      {{- end }}
   selector:
     component: "{{ .Release.Name }}-spark-master"

--- a/spark/values.yaml
+++ b/spark/values.yaml
@@ -8,6 +8,9 @@ master:
   imageTag: "2.2.0_v2"
   imagePullPolicy: IfNotPresent
   replicas: 1
+  service:
+    type: ClusterIP
+    port: 7077
   # Additional volumes for the Master pod
   additionalVolumes: []
   # Additional volume mounts for the Master container

--- a/spark/values.yaml
+++ b/spark/values.yaml
@@ -8,9 +8,6 @@ master:
   imageTag: "2.2.0_v2"
   imagePullPolicy: IfNotPresent
   replicas: 1
-  service:
-    type: ClusterIP
-    port: 7077
   # Additional volumes for the Master pod
   additionalVolumes: []
   # Additional volume mounts for the Master container


### PR DESCRIPTION
Changes needed to run spark 2.3.2 

* The service needs to be headless
  Since master dynamically creates dedicated RPC port for each worker
  you won't be able to route workers to master.

* The spark.driver.host parameter is auto set to the pod hostname.
  This variable is created by the spark context and sent to the workers.
  The workers tries to talk back with the master using this address
  so we need to have this hostname being resolved by the DNS.

* The host and port parameter are set via ENV Variables