### PR TITLE
Make gitbase username/password optional in sourced-ui

### DIFF
--- a/sourced-ui/Chart.yaml
+++ b/sourced-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: sourced-ui
-version: 0.3.0
+version: 0.4.0
 home: https://github.com/src-d/sourced-ui

--- a/sourced-ui/templates/deployment.yaml
+++ b/sourced-ui/templates/deployment.yaml
@@ -76,13 +76,17 @@ spec:
               value: "{{ default "3306" .Values.gitbase.port }}"
             - name: GITBASE_DB
               value: "{{ required "missing gitbase.db value" .Values.gitbase.db }}"
+            {{- if .Values.gitbase.user }}
             - name: GITBASE_USER
-              value: "{{ required "missing gitbase.user value" .Values.gitbase.user }}"
+              value: "{{ .Values.gitbase.user }}"
+            {{- end }}
+            {{- if (or .Values.gitbase.secretName .Values.gitbase.password) }}
             - name: GITBASE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   key: password
                   name: "{{ default (include "sourced-ui.gitbase.secretName" .) .Values.gitbase.secretName }}"
+            {{- end }}
             - name: BBLFSH_WEB_HOST
               value: "{{ required "missing bblfshWeb.host value" .Values.bblfshWeb.host }}"
             - name: BBLFSH_WEB_PORT

--- a/sourced-ui/templates/gitbase-secret.yaml
+++ b/sourced-ui/templates/gitbase-secret.yaml
@@ -1,5 +1,5 @@
 # create secrets only if there is no name for existing secrets
-{{- if not .Values.gitbase.secretName }}
+{{- if .Values.gitbase.password }}
 ---
 apiVersion: v1
 kind: Secret

--- a/sourced-ui/values.yaml
+++ b/sourced-ui/values.yaml
@@ -55,7 +55,7 @@ gitbase: {}
   # host: <required>
   # port: 3306
   # db: <required>
-  # user: <required>
+  # user: ""
   # password: ""
   # secretName:
 


### PR DESCRIPTION
Making this optional is needed for deployment with a Spark SQL backend.
If a username and password are specified the Spark SQL backend will fail to
connect as there is no LDAP authentication configured.

Signed-off-by: Maartje Eyskens <maartje@eyskens.me>