### PR TITLE
Make thrift server aware of core limits

### DIFF
--- a/stable/spark-thrift-server/Chart.yaml
+++ b/stable/spark-thrift-server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: spark-thrift-server
-version: 0.5.0
+version: 0.6.0
 home: https://spark.apache.org/docs/latest/sql-distributed-sql-engine.html

--- a/stable/spark-thrift-server/templates/deployment.yaml
+++ b/stable/spark-thrift-server/templates/deployment.yaml
@@ -48,11 +48,11 @@ spec:
             - --packages
             - org.postgresql:postgresql:42.2.5
             - /opt/jars/gitbase-spark-connector-enterprise-uber.jar
-            {{- if .Values.app.executor-cores }}
+            {{- if .Values.app.executorCores }}
             - --conf
             - spark.executor.cores={{ .Values.app.executorCores }}
             {{- end }}
-            {{- if .Values.app.max-cores }}
+            {{- if .Values.app.maxCores }}
             - --conf
             - spark.cores.max={{ .Values.app.maxCores}}
             {{- end }}

--- a/stable/spark-thrift-server/templates/deployment.yaml
+++ b/stable/spark-thrift-server/templates/deployment.yaml
@@ -31,6 +31,14 @@ spec:
             - /opt/spark-2.3.2-bin-hadoop2.7/bin/spark-submit
             - --master
             - {{ required "Missing app.sparkMasterURI" .Values.app.sparkMasterURI | quote }}
+            {{- if .Values.app.executorCores }}
+            - --conf
+            - spark.executor.cores={{ .Values.app.executorCores }}
+            {{- end }}
+            {{- if .Values.app.maxCores }}
+            - --conf
+            - spark.cores.max={{ .Values.app.maxCores}}
+            {{- end }}            
             - --conf
             - "spark.datasource.gitbase.user={{ .Values.app.gitbaseUser }}"
             - --conf
@@ -48,14 +56,6 @@ spec:
             - --packages
             - org.postgresql:postgresql:42.2.5
             - /opt/jars/gitbase-spark-connector-enterprise-uber.jar
-            {{- if .Values.app.executorCores }}
-            - --conf
-            - spark.executor.cores={{ .Values.app.executorCores }}
-            {{- end }}
-            {{- if .Values.app.maxCores }}
-            - --conf
-            - spark.cores.max={{ .Values.app.maxCores}}
-            {{- end }}
           env:
             - name: POD_IP
               valueFrom:

--- a/stable/spark-thrift-server/templates/deployment.yaml
+++ b/stable/spark-thrift-server/templates/deployment.yaml
@@ -48,6 +48,14 @@ spec:
             - --packages
             - org.postgresql:postgresql:42.2.5
             - /opt/jars/gitbase-spark-connector-enterprise-uber.jar
+            {{- if .Values.app.executor-cores }}
+            - --conf
+            - spark.executor.cores={{ .Values.app.executorCores }}
+            {{- end }}
+            {{- if .Values.app.max-cores }}
+            - --conf
+            - spark.cores.max={{ .Values.app.maxCores}}
+            {{- end }}
           env:
             - name: POD_IP
               valueFrom:

--- a/stable/spark-thrift-server/values.yaml
+++ b/stable/spark-thrift-server/values.yaml
@@ -18,6 +18,8 @@ app:
   gitbaseUser: gitbase
   gitbasePassword: gitbase
   # gitbasePasswordSecretName:
+  # executorCores: 1
+  # maxCores: 1
 
 
 service:


### PR DESCRIPTION
Allow to set `spark.executor.cores` and `spark.cores.max`

Signed-off-by: David Riosalido <driosalido@gmail.com>