### PR TITLE
Add tests to Spark chart

### DIFF
--- a/ct-install.yaml
+++ b/ct-install.yaml
@@ -42,7 +42,6 @@ excluded-charts:
   - rovers
   - scylla
   - sourced-ui
-  - spark
   - spark-api-jupyter
   - spark-thrift-server
   - k8s-pod-headless-service-operator

--- a/stable/spark/Chart.yaml
+++ b/stable/spark/Chart.yaml
@@ -17,7 +17,7 @@
 
 apiVersion: v1
 name: spark
-version: 1.1.1
+version: 1.2.0
 appVersion: 2.2.0
 description: Fast and general-purpose cluster computing system.
 home: http://spark.apache.org

--- a/stable/spark/templates/tests/test-job-pod.yaml
+++ b/stable/spark/templates/tests/test-job-pod.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-test-job"
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+  - name: {{ .Release.Name }}-test-job
+    image: "{{ .Values.worker.image }}:{{ .Values.worker.imageTag }}"
+    env:
+      - name: POD_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+    command: 
+        - spark-submit 
+        - --master
+        - spark://{{ template "master-fullname" . }}:{{ .Values.master.service.port }}  
+        - --class 
+        - org.apache.spark.examples.SparkPi 
+        - --executor-memory 
+        - 1G
+        - --total-executor-cores 
+        - "1"
+        - --conf
+        - "spark.driver.host=$(POD_IP)"
+        - /opt/spark-2.2.0-bin-hadoop2.7/examples/jars/spark-examples_2.11-2.2.0.jar
+        - "1"
+  restartPolicy: Never

--- a/stable/spark/templates/tests/test-webui-configmap.yaml
+++ b/stable/spark/templates/tests/test-webui-configmap.yaml
@@ -1,0 +1,16 @@
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-test-webui
+data:
+  tests.sh: |
+    @test "redirect" {
+      statusCode=$(curl -I -X GET http://{{ template "webui-proxy-fullname" . }}:{{ .Values.webUIProxy.service.port }} | head -n 1 | cut -d$' ' -f2)
+      [ "$statusCode" == "302" ]
+    }
+
+    @test "Check if cluster reports alive" {
+      alive=$(curl http://{{ template "webui-proxy-fullname" . }}:{{ .Values.webUIProxy.service.port }}/proxy:{{ template "webui-fullname" . }}:{{ .Values.webUI.service.port }} | grep -c ALIVE)
+      [ "$alive" -ge 1 ]
+    }

--- a/stable/spark/templates/tests/test-webui-configmap.yaml
+++ b/stable/spark/templates/tests/test-webui-configmap.yaml
@@ -11,6 +11,6 @@ data:
     }
 
     @test "Check if cluster reports alive" {
-      alive=$(curl http://{{ template "webui-proxy-fullname" . }}:{{ .Values.webUIProxy.service.port }}/proxy:{{ template "webui-fullname" . }}:{{ .Values.webUI.service.port }} | grep -c ALIVE)
+      alive=$(curl http://{{ template "webui-proxy-fullname" . }}:{{ .Values.webUIProxy.service.port }}/proxy:{{ template "webui-fullname" . }}:{{ .Values.webUI.service.port }} | grep -c "Status:.*ALIVE")
       [ "$alive" -ge 1 ]
     }

--- a/stable/spark/templates/tests/test-webui.yaml
+++ b/stable/spark/templates/tests/test-webui.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-test-webui"
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  volumes:
+    - name: tools
+      emptyDir: {}
+    - name: tests
+      configMap:
+        name: {{ .Release.Name }}-test-webui
+  initContainers:
+  - name: test-framework
+    image: dduportal/bats:0.4.0
+    command:
+      - bash
+      - -c
+      - |
+        set -ex
+        # copy bats to tools dir
+        cp -R /usr/local/libexec/ /tools/bats/
+    volumeMounts:
+    volumeMounts:
+      - name: tools
+        mountPath: /tools
+  containers:
+  - name: {{ .Release.Name }}-test-webui
+    image: alpine
+    volumeMounts:
+      - name: tools
+        mountPath: /tools
+      - name: tests
+        mountPath: /tests
+    command: 
+      - sh
+      - -c
+      - |
+        apk add --no-cache bash curl
+        /tools/bats/bats -t /tests/tests.sh
+  restartPolicy: Never


### PR DESCRIPTION
This adds 2 tests to the Spark chart.
1 will launch a test job to see if the setup works
The other will test the web ui and the liveness reported

Signed-off-by: Maartje Eyskens <maartje@eyskens.me>