### PR TITLE
added tests to bblfshd chart

### DIFF
--- a/ct-install.yaml
+++ b/ct-install.yaml
@@ -17,7 +17,6 @@ chart-dirs:
 # Some are included as they do not have the required dependancies to test
 excluded-charts:
   - bblfsh-web
-  - bblfshd
   - bblfshd-sidecar
   - borges
   - drone

--- a/stable/bblfshd/Chart.yaml
+++ b/stable/bblfshd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: bblfshd
-version: 0.6.2
+version: 0.7.0
 appVersion: 2.14.0
 home: https://doc.bblf.sh/
 maintainers:

--- a/stable/bblfshd/ci/test-values.yaml
+++ b/stable/bblfshd/ci/test-values.yaml
@@ -1,0 +1,3 @@
+image:
+  tag: latest-drivers
+  pullPolicy: Always

--- a/stable/bblfshd/templates/tests/test-configmap.yaml
+++ b/stable/bblfshd/templates/tests/test-configmap.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}-test
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  tests.py: |-
+    import unittest
+    import bblfsh
+
+    class TestConnection(unittest.TestCase):
+        def test_connection(self):
+            client = bblfsh.BblfshClient("{{ template "fullname" . }}:{{ .Values.service.externalPort }}")
+            self.assertNotEqual(client.parse(__file__), '')
+
+    if __name__ == '__main__':
+        unittest.main()

--- a/stable/bblfshd/templates/tests/test.yaml
+++ b/stable/bblfshd/templates/tests/test.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ template "fullname" . }}-test"
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  volumes:
+    - name: tests
+      configMap:
+        name: {{ template "fullname" . }}-test
+  containers:
+  - name: {{ .Release.Name }}-test
+    image: python:3.7-slim
+    volumeMounts:
+      - name: tests
+        mountPath: /tests
+    command:
+      - sh
+      - -c
+      - |
+        apt-get update
+        apt-get install -y gcc make g++
+        pip install bblfsh
+        python /tests/tests.py
+  restartPolicy: Never


### PR DESCRIPTION
Tests have been written in Python using bblfsh python client as we
don't have a bblfsh cli yet that we can download easily for these tests
(see bblfsh/go-client#115)

Signed-off-by: Rafael Porres Molina <rafa@sourced.tech>