### PR TITLE
Only install minikube if charts are changed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,18 +45,10 @@ jobs:
         - sudo apt-get update
         - sudo apt-get install -y socat
       before_script:
-        - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl
-        - sudo chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-        - curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 
-        - sudo chmod +x minikube && sudo mv minikube /usr/local/bin/
-        - sudo minikube start --vm-driver=none --kubernetes-version=${KUBERNETES_VERSION}
-        - sudo chown -R travis /home/travis/.minikube/
-        - minikube update-context
-        # wait till node is ready
-        - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
         - curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
         - chmod 700 get_helm.sh
         - DESIRED_VERSION=$HELM_VERSION ./get_helm.sh
+        - ./scripts/install-minikube.sh
         - curl -Lo chart-testing_${CT_VERSION}_linux_amd64.tar.gz https://github.com/helm/chart-testing/releases/download/v${CT_VERSION}/chart-testing_${CT_VERSION}_linux_amd64.tar.gz
         - tar xzf chart-testing_${CT_VERSION}_linux_amd64.tar.gz
         - sudo chmod +x ct && sudo mv ct /usr/local/bin/
@@ -65,9 +57,6 @@ jobs:
         - git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # Configure Travis CI to pull all branches, needed for CT to compare changes
         - git fetch
       script:
-        - helm init
-        # wait till the tiller is ready
-        - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get pods -n kube-system -l name=tiller -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
         - ct install --config ct-install.yaml
     - name: Repo sync
       stage: repo-sync

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,8 @@ jobs:
         - sudo apt-get update
         - sudo apt-get install -y socat
       before_script:
+        - git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # Configure Travis CI to pull all branches, needed for CT to compare changes
+        - git fetch
         - sudo pip install yq
         - curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
         - chmod 700 get_helm.sh
@@ -55,8 +57,6 @@ jobs:
         - sudo chmod +x ct && sudo mv ct /usr/local/bin/
         - sudo mv etc /etc/ct
         - rm -f chart-testing_${CT_VERSION}_linux_amd64.tar.gz
-        - git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # Configure Travis CI to pull all branches, needed for CT to compare changes
-        - git fetch
       script:
         - ct install --config ct-install.yaml
     - name: Repo sync

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
         - sudo apt-get update
         - sudo apt-get install -y socat
       before_script:
-        - pip install yq
+        - sudo pip install yq
         - curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
         - chmod 700 get_helm.sh
         - DESIRED_VERSION=$HELM_VERSION ./get_helm.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ jobs:
         - sudo apt-get update
         - sudo apt-get install -y socat
       before_script:
+        - pip install yq
         - curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
         - chmod 700 get_helm.sh
         - DESIRED_VERSION=$HELM_VERSION ./get_helm.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ jobs:
         - CT_VERSION=2.3.3
         - HELM_VERSION=v2.14.0
       before_script:
+        - git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # Configure Travis CI to pull all branches, needed for CT to compare changes
+        - git fetch
         - sudo pip install yamale yamllint
         - curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
         - chmod 700 get_helm.sh
@@ -30,8 +32,6 @@ jobs:
         - sudo chmod +x ct && sudo mv ct /usr/local/bin/
         - sudo mv etc /etc/ct
         - rm -f chart-testing_${CT_VERSION}_linux_amd64.tar.gz
-        - git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # Configure Travis CI to pull all branches, needed for CT to compare changes
-        - git fetch
       script:
         - ct lint --config ct.yaml
     - name: Tests

--- a/scripts/install-minikube.sh
+++ b/scripts/install-minikube.sh
@@ -4,7 +4,7 @@ set -e
 
 CHANGED_FILES=$(git diff --name-only "$TRAVIS_COMMIT_RANGE")
 if [ "$TRAVIS_BRANCH" != "master" ]; then
-    CHANGED_FILES=$(git diff --name-only "master...$TRAVIS_BRANCH")
+    CHANGED_FILES=$(git diff --name-only "origin/master..$TRAVIS_BRANCH")
 fi
 
 # Remove excluded charts from the changes list

--- a/scripts/install-minikube.sh
+++ b/scripts/install-minikube.sh
@@ -4,7 +4,7 @@ set -e
 
 CHANGED_FILES=$(git diff --name-only "$TRAVIS_COMMIT_RANGE")
 if [ "$TRAVIS_BRANCH" != "master" ]; then
-    CHANGED_FILES=$(git diff --name-only "HEAD...$TRAVIS_BRANCH")
+    CHANGED_FILES=$(git diff --name-only "master...$TRAVIS_BRANCH")
 fi
 
 # Remove excluded charts from the changes list

--- a/scripts/install-minikube.sh
+++ b/scripts/install-minikube.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+CHANGED_FILES=$(mktemp)
+trap "rm -f $CHANGED_FILES" EXIT
+
+git diff --name-only "$TRAVIS_COMMIT_RANGE" > "$CHANGED_FILES"
+
+grep 'Chart.yaml$' "$CHANGED_FILES" || { echo "No Chart.yaml files changed. No need to hate Kubernetes. Exiting."; exit 0; }
+
+curl -Lo kubectl "https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl"
+sudo chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 
+sudo chmod +x minikube && sudo mv minikube /usr/local/bin/
+sudo minikube start --vm-driver=none --kubernetes-version="${KUBERNETES_VERSION}"
+sudo chown -R travis /home/travis/.minikube/
+minikube update-context
+
+# wait till node is ready
+JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
+
+helm init
+# wait till the tiller is ready
+JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get pods -n kube-system -l name=tiller -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done

--- a/scripts/install-minikube.sh
+++ b/scripts/install-minikube.sh
@@ -3,6 +3,9 @@
 set -e
 
 CHANGED_FILES=$(git diff --name-only "$TRAVIS_COMMIT_RANGE")
+if [ "$TRAVIS_BRANCH" != "master" ]; then
+    CHANGED_FILES=$(git diff --name-only "HEAD...$TRAVIS_BRANCH")
+fi
 
 # Remove excluded charts from the changes list
 excluded_charts=$(yq -r ".\"excluded-charts\" | .[]" ct-install.yaml)

--- a/scripts/install-minikube.sh
+++ b/scripts/install-minikube.sh
@@ -2,19 +2,16 @@
 
 set -e
 
-CHANGED_FILES=$(mktemp)
-trap "rm -f $CHANGED_FILES" EXIT
-
-git diff --name-only "$TRAVIS_COMMIT_RANGE" > "$CHANGED_FILES"
+CHANGED_FILES=$(git diff --name-only "$TRAVIS_COMMIT_RANGE")
 
 # Remove excluded charts from the changes list
 excluded_charts=$(yq -r ".\"excluded-charts\" | .[]" ct-install.yaml)
 for chart in $excluded_charts
 do
-    CHANGED_FILES=$(grep -v "$chart/Chart.yaml" )
+    CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v "$chart/Chart.yaml" )
 done
 
-grep 'Chart.yaml$' "$CHANGED_FILES" || { echo "No Chart.yaml files changed. No need to have Kubernetes. Exiting."; exit 0; }
+echo "$CHANGED_FILES" | grep 'Chart.yaml$' || { echo "No Chart.yaml files changed. No need to have Kubernetes. Exiting."; exit 0; }
 
 curl -Lo kubectl "https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl"
 sudo chmod +x kubectl && sudo mv kubectl /usr/local/bin/


### PR DESCRIPTION
This checks if the charts that need to be installed are changed on the test step.
Only then it will set up Minikube, this will save several minutes on releasing charts that do not have tests (yet)