### PR TITLE
Improve the bblfshd chart

### DIFF
--- a/stable/bblfshd/Chart.yaml
+++ b/stable/bblfshd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: bblfshd
-version: 0.7.0
+version: 1.0.0
 appVersion: 2.14.0
 home: https://doc.bblf.sh/
 maintainers:

--- a/stable/bblfshd/ci/test-values.yaml
+++ b/stable/bblfshd/ci/test-values.yaml
@@ -1,3 +1,0 @@
-image:
-  tag: latest-drivers
-  pullPolicy: Always

--- a/stable/bblfshd/templates/NOTES.txt
+++ b/stable/bblfshd/templates/NOTES.txt
@@ -1,15 +1,15 @@
 1. Get the application URL by running these commands:
 {{- if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "bblfshd.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   You can access bblfsh server in $SERVICE_IP:{{ .Values.service.externalPort }}
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+           You can watch the status of by running 'kubectl get svc -w {{ template "bblfshd.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "bblfshd.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   You can access bblfsh server in $SERVICE_IP:{{ .Values.service.externalPort }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "bblfshd.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   You can access bblfsh server in localhost:9432
   kubectl port-forward $POD_NAME 9432:{{ .Values.service.externalPort }}
 {{- end }}

--- a/stable/bblfshd/templates/_helpers.tpl
+++ b/stable/bblfshd/templates/_helpers.tpl
@@ -2,15 +2,31 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "bblfshd.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
-{{- define "fullname" -}}
+{{- define "bblfshd.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "bblfshd.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/stable/bblfshd/templates/deployment.yaml
+++ b/stable/bblfshd/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/install-drivers-configmap.yaml") . | sha256sum }}
       labels:
-        app: {{ template "bblfshd.name" . }}
+        app: {{ template "bblfshd.fullname" . }}
         release: {{ .Release.Name }}
     spec:
       {{- if .Values.drivers.install }}

--- a/stable/bblfshd/templates/deployment.yaml
+++ b/stable/bblfshd/templates/deployment.yaml
@@ -1,34 +1,41 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "bblfshd.fullname" . }}
   labels:
-    app: {{ template "name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app: {{ template "bblfshd.name" . }}
+    chart: {{ template "bblfshd.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "bblfshd.fullname" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       # This is to upgrade the deployment if configmap changes
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/install-drivers-configmap.yaml") . | sha256sum }}
       labels:
-        app: {{ template "name" . }}
+        app: {{ template "bblfshd.name" . }}
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.drivers.install }}
       volumes:
         - configMap:
-            name: {{ template "fullname" . }}-install-drivers
+            name: {{ template "bblfshd.fullname" . }}-install-drivers
             items:
             - key: install-bblfshd-drivers.sh
               path: install-bblfshd-drivers.sh
           name: install-bblfshd-drivers-volume
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.drivers.install }}
           volumeMounts:
             - name: install-bblfshd-drivers-volume
               mountPath: /opt/install-bblfshd-drivers.sh
@@ -37,8 +44,10 @@ spec:
             postStart:
               exec:
                 command: [ "sh", "/opt/install-bblfshd-drivers.sh" ]
+          {{- end }}
           ports:
-            - containerPort: {{ .Values.service.internalPort }}
+            - name: bblfshd
+              containerPort: {{ .Values.service.internalPort }}
           {{- if .Values.metrics.enabled }}
             - name: metrics
               containerPort: 2112

--- a/stable/bblfshd/templates/deployment.yaml
+++ b/stable/bblfshd/templates/deployment.yaml
@@ -47,17 +47,17 @@ spec:
           {{- end }}
           ports:
             - name: bblfshd
-              containerPort: {{ .Values.service.internalPort }}
+              containerPort: 9432
           {{- if .Values.metrics.enabled }}
             - name: metrics
               containerPort: 2112
           {{- end }}
           livenessProbe:
             tcpSocket:
-              port: {{ .Values.service.internalPort }}
+              port: 9432
           readinessProbe:
             tcpSocket:
-              port: {{ .Values.service.internalPort }}
+              port: 9432
           securityContext:
             privileged: true
           resources:

--- a/stable/bblfshd/templates/deployment.yaml
+++ b/stable/bblfshd/templates/deployment.yaml
@@ -11,7 +11,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "bblfshd.fullname" . }}
+      app: {{ template "bblfshd.name" . }}
       release: {{ .Release.Name }}
   template:
     metadata:

--- a/stable/bblfshd/templates/deployment.yaml
+++ b/stable/bblfshd/templates/deployment.yaml
@@ -11,7 +11,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "bblfshd.name" . }}
+      app: {{ template "bblfshd.fullname" . }}
       release: {{ .Release.Name }}
   template:
     metadata:

--- a/stable/bblfshd/templates/install-drivers-configmap.yaml
+++ b/stable/bblfshd/templates/install-drivers-configmap.yaml
@@ -1,11 +1,16 @@
+{{- if .Values.drivers.install }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "fullname" . }}-install-drivers
+  name: {{ template "bblfshd.fullname" . }}-install-drivers
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "bblfshd.name" . }}
+    chart: {{ template "bblfshd.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 data:
   install-bblfshd-drivers.sh: |
     {{- range $language, $driver := .Values.drivers.languages }}
     bblfshctl driver install {{ $language }} {{ $driver.repository }}:{{ $driver.tag }}
     {{- end }}
+{{- end }}

--- a/stable/bblfshd/templates/service.yaml
+++ b/stable/bblfshd/templates/service.yaml
@@ -1,22 +1,23 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "bblfshd.fullname" . }}
   labels:
-    app: {{ template "name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app: {{ template "bblfshd.name" . }}
+    chart: {{ template "bblfshd.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
   type: {{ .Values.service.type }}
   {{- if .Values.service.loadBalancerIP }}
-  loadBalancerIP: {{ default "" .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
   ports:
-    - port: {{ .Values.service.externalPort }}
-      targetPort: {{ .Values.service.internalPort }}
+    - port: {{ .Values.service.port }}
+      targetPort: bblfshd
       protocol: TCP
-      name: {{ .Values.service.name }}
+      name: bblfshd
   {{- if .Values.metrics.enabled }}
     - name: metrics
       port: 2112
@@ -24,5 +25,5 @@ spec:
       targetPort: metrics
   {{- end }}
   selector:
-    app: {{ template "name" . }}
+    app: {{ template "bblfshd.fullname" . }}
     release: {{ .Release.Name }}

--- a/stable/bblfshd/templates/servicemonitor.yaml
+++ b/stable/bblfshd/templates/servicemonitor.yaml
@@ -2,18 +2,18 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "bblfshd.fullname" . }}
   namespace: {{ .Values.metrics.namespace }}
   labels:
-    app: {{ template "name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app: {{ template "bblfshd.name" . }}
+    chart: {{ template "bblfshd.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
   selector:
     matchLabels:
-        app: {{ template "name" . }}
-        chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app: {{ template "bblfshd.name" . }}
+        chart: {{ template "bblfshd.chart" . }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
   endpoints:

--- a/stable/bblfshd/templates/tests/test-configmap.yaml
+++ b/stable/bblfshd/templates/tests/test-configmap.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "fullname" . }}-test
+  name: {{ template "bblfshd.fullname" . }}-test
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "bblfshd.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -14,7 +14,7 @@ data:
 
     class TestConnection(unittest.TestCase):
         def test_connection(self):
-            client = bblfsh.BblfshClient("{{ template "fullname" . }}:{{ .Values.service.externalPort }}")
+            client = bblfsh.BblfshClient("{{ template "bblfshd.fullname" . }}:{{ .Values.service.externalPort }}")
             self.assertNotEqual(client.parse(__file__), '')
 
     if __name__ == '__main__':

--- a/stable/bblfshd/templates/tests/test-configmap.yaml
+++ b/stable/bblfshd/templates/tests/test-configmap.yaml
@@ -14,7 +14,7 @@ data:
 
     class TestConnection(unittest.TestCase):
         def test_connection(self):
-            client = bblfsh.BblfshClient("{{ template "bblfshd.fullname" . }}:{{ .Values.service.externalPort }}")
+            client = bblfsh.BblfshClient("{{ template "bblfshd.fullname" . }}:{{ .Values.service.port }}")
             self.assertNotEqual(client.parse(__file__), '')
 
     if __name__ == '__main__':

--- a/stable/bblfshd/templates/tests/test.yaml
+++ b/stable/bblfshd/templates/tests/test.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ template "fullname" . }}-test"
+  name: "{{ template "bblfshd.fullname" . }}-test"
   annotations:
     "helm.sh/hook": test-success
 spec:
   volumes:
     - name: tests
       configMap:
-        name: {{ template "fullname" . }}-test
+        name: {{ template "bblfshd.fullname" . }}-test
   containers:
   - name: {{ .Release.Name }}-test
     image: python:3.7-slim

--- a/stable/bblfshd/values.yaml
+++ b/stable/bblfshd/values.yaml
@@ -2,46 +2,48 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 replicaCount: 1
+
 image:
   repository: bblfsh/bblfshd
-  tag: v2.14.0
+  tag: v2.14.0-drivers
   pullPolicy: IfNotPresent
+
 service:
-  name: bblfshd
   type: ClusterIP
-  externalPort: 9432
-  internalPort: 9432
-  # loadBalancerIP: 1.2.3.4
+  port: 80
+  # loadBalancerIP
+
 drivers:
-  install: true
-  languages:
-    python:
-      repository: bblfsh/python-driver
-      tag: latest
-    java:
-      repository: bblfsh/java-driver
-      tag: latest
-    javascript:
-      repository: bblfsh/javascript-driver
-      tag: latest
-    typescript:
-      repository: bblfsh/typescript-driver
-      tag: latest
-    bash:
-      repository: bblfsh/bash-driver
-      tag: latest
-    ruby:
-      repository: bblfsh/ruby-driver
-      tag: latest
-    go:
-      repository: bblfsh/go-driver
-      tag: latest
-    php:
-      repository: bblfsh/php-driver
-      tag: latest
-    csharp:
-      repository: bblfsh/csharp-driver
-      tag: latest
+  install: false
+  languages: {}
+    # python:
+    #   repository: bblfsh/python-driver
+    #   tag: latest
+    # java:
+    #   repository: bblfsh/java-driver
+    #   tag: latest
+    # javascript:
+    #   repository: bblfsh/javascript-driver
+    #   tag: latest
+    # typescript:
+    #   repository: bblfsh/typescript-driver
+    #   tag: latest
+    # bash:
+    #   repository: bblfsh/bash-driver
+    #   tag: latest
+    # ruby:
+    #   repository: bblfsh/ruby-driver
+    #   tag: latest
+    # go:
+    #   repository: bblfsh/go-driver
+    #   tag: latest
+    # php:
+    #   repository: bblfsh/php-driver
+    #   tag: latest
+    # csharp:
+    #   repository: bblfsh/csharp-driver
+    #   tag: latest
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
@@ -54,7 +56,9 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
   #
+
 affinity: {}
+
 metrics:
   enabled: false
   interval: 10s

--- a/stable/bblfshd/values.yaml
+++ b/stable/bblfshd/values.yaml
@@ -10,7 +10,7 @@ image:
 
 service:
   type: ClusterIP
-  port: 80
+  port: 9432
   # loadBalancerIP
 
 drivers:


### PR DESCRIPTION
This updates the bblfshd chart to the latest Helm and Kubernetes standards,
It is a breaking change as it will rename the resources differently when the
chart name is equal to the release name.

Signed-off-by: Maartje Eyskens <maartje@eyskens.me>