### PR TITLE
Fix default ingress path

### DIFF
--- a/stable/bblfsh-web/Chart.yaml
+++ b/stable/bblfsh-web/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: bblfsh-web
-version: 1.0.0
+version: 1.0.1
 appVersion: 0.11.0
 description: |
     A web interface for Babelfish (https://doc.bblf.sh/).

--- a/stable/bblfsh-web/values.yaml
+++ b/stable/bblfsh-web/values.yaml
@@ -18,7 +18,7 @@ ingress:
   annotations:
     kubernetes.io/ingress.class: gce
     kubernetes.io/tls-acme: "true"
-  path: /
+  path: /*
   hosts:
     - chart-example.local
   tls: []

--- a/stable/bblfshd/Chart.yaml
+++ b/stable/bblfshd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: bblfshd
-version: 1.0.2
+version: 1.0.1
 appVersion: 2.14.0
 home: https://doc.bblf.sh/
 maintainers:

--- a/stable/bblfshd/Chart.yaml
+++ b/stable/bblfshd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: bblfshd
-version: 1.0.1
+version: 1.0.2
 appVersion: 2.14.0
 home: https://doc.bblf.sh/
 maintainers:


### PR DESCRIPTION
The GKE ingress controller sees / as only the root, changed it to /*

Signed-off-by: Maartje Eyskens <maartje@eyskens.me>