### PR TITLE
Use Caddy 1.0.3

### DIFF
--- a/infra/website-redirect/Chart.yaml
+++ b/infra/website-redirect/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to redirect all requests to another URL
 name: website-redirect
-version: 1.0.1
+version: 1.0.2
 home: https://github.com/src-d/charts
 maintainers:
 - email: infra@sourced.tech

--- a/infra/website-redirect/values.yaml
+++ b/infra/website-redirect/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: abiosoft/caddy
-  tag: 0.11.0
+  tag: 1.0.3
   pullPolicy: IfNotPresent
 
 redirects: []


### PR DESCRIPTION
Caddy 1.0.3 contains a fix for a HTTP/2 DoS

Signed-off-by: Maartje Eyskens <maartje@eyskens.me>